### PR TITLE
tec: Use feed entry id as link if the link is missing

### DIFF
--- a/src/services/FeedFetcher.php
+++ b/src/services/FeedFetcher.php
@@ -124,6 +124,10 @@ class FeedFetcher
         $links_to_collections_to_create = [];
 
         foreach ($feed->entries as $entry) {
+            if (!$entry->link && \SpiderBits\Url::isValid($entry->id)) {
+                $entry->link = $entry->id;
+            }
+
             if (!$entry->link) {
                 continue;
             }

--- a/tests/jobs/scheduled/FeedsSyncTest.php
+++ b/tests/jobs/scheduled/FeedsSyncTest.php
@@ -489,6 +489,65 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($collection->feed_fetched_at);
     }
 
+    public function testPerformUsesIdAsLinkIfEntryHasNoLink(): void
+    {
+        $feed_url = 'https://flus.fr/carnet/feeds/all.atom.xml';
+        $link_url = 'https://flus.fr/carnet/nouveautes-mars-2021.html';
+        /** @var string */
+        $old_name = $this->fakeUnique('sentence');
+        /** @var string */
+        $expected_name = $this->fakeUnique('sentence');
+        /** @var string */
+        $expected_title = $this->fakeUnique('sentence');
+        $collection = CollectionFactory::create([
+            'type' => 'feed',
+            'name' => $old_name,
+            'feed_url' => $feed_url,
+            'feed_fetched_at' => \Minz\Time::ago(2, 'hours'),
+        ]);
+        $user = UserFactory::create([
+            'validated_at' => \Minz\Time::now(),
+        ]);
+        FollowedCollectionFactory::create([
+            'collection_id' => $collection->id,
+            'user_id' => $user->id,
+        ]);
+        $hash = \SpiderBits\Cache::hash($feed_url);
+        $raw_response = <<<XML
+        HTTP/2 200 OK
+        Content-Type: application/xml
+
+        <?xml version='1.0' encoding='UTF-8'?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>carnet de flus</title>
+            <link href="https://flus.fr/carnet/feeds/all.atom.xml" rel="self" type="application/atom+xml" />
+            <link href="https://flus.fr/carnet/" rel="alternate" type="text/html" />
+            <id>urn:uuid:4c04fe8e-c966-5b7e-af89-74d092a6ccb0</id>
+            <updated>2021-03-30T11:26:00+02:00</updated>
+            <entry>
+                <title>Les nouveautés de mars 2021</title>
+                <id>{$link_url}</id>
+                <author><name>Marien</name></author>
+                <published>2021-03-30T11:26:00+02:00</published>
+                <updated>2021-03-30T11:26:00+02:00</updated>
+                <content type="html"></content>
+            </entry>
+        </feed>
+        XML;
+        /** @var string */
+        $cache_path = \Minz\Configuration::$application['cache_path'];
+        $cache = new \SpiderBits\Cache($cache_path);
+        $cache->save($hash, $raw_response);
+        $feeds_sync_job = new FeedsSync();
+
+        $feeds_sync_job->perform();
+
+        $this->assertSame(1, models\Link::count());
+        $link = models\Link::take();
+        $this->assertNotNull($link);
+        $this->assertSame($link_url, $link->url);
+    }
+
     public function testPerformIgnoresEntriesWithNoLink(): void
     {
         $feed_url = 'https://flus.fr/carnet/feeds/all.atom.xml';


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
