### PR TITLE
fix: Fix group headers positionning

### DIFF
--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -17,6 +17,7 @@ import ModalOpenerController from './controllers/modal_opener_controller.js';
 import NewsRefresherController from './controllers/news_refresher_controller.js';
 import PopupController from './controllers/popup_controller.js';
 import TextEditorController from './controllers/text_editor_controller.js';
+import ZindexInverserController from './controllers/zindex_inverser_controller.js';
 
 window.jsConfiguration = JSON.parse(document.getElementById('javascript-configuration').innerHTML);
 
@@ -37,6 +38,7 @@ application.register('modal-opener', ModalOpenerController);
 application.register('news-refresher', NewsRefresherController);
 application.register('popup', PopupController);
 application.register('text-editor', TextEditorController);
+application.register('zindex-inverser', ZindexInverserController);
 
 function adaptLayoutContentBorderRadius () {
     const layoutContentNode = document.querySelector('.layout__content');

--- a/src/assets/javascripts/controllers/zindex_inverser_controller.js
+++ b/src/assets/javascripts/controllers/zindex_inverser_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static get targets () {
+        return ['item'];
+    }
+
+    connect () {
+        const baseZindex = 10;
+        const zindexMax = this.itemTargets.length;
+        this.itemTargets.forEach((item, index) => {
+            item.style.zIndex = baseZindex + zindexMax - index;
+        });
+    }
+}

--- a/src/assets/stylesheets/custom/groups.css
+++ b/src/assets/stylesheets/custom/groups.css
@@ -4,6 +4,7 @@
 
 .group__header {
     position: sticky;
+    z-index: 1;
     top: 0;
 
     display: flex;
@@ -14,55 +15,6 @@
 
     background-color: var(--color-white);
     box-shadow: 0 2px 2px var(--color-white);
-}
-
-/**
- * This is a hack to create a descending z-index priority over the
- * group__headers. This is because if a group__header has a popup menu in it,
- * the stacking context (created because of the sticky property) makes it
- * appear below the next group__header. This is the case in the news for
- * instance.
- * The hack only works for 10 elements, but hopefully, this should be enough
- * most of the time.
- */
-.group:nth-child(1) .group__header {
-    z-index: 20;
-}
-
-.group:nth-child(2) .group__header {
-    z-index: 19;
-}
-
-.group:nth-child(3) .group__header {
-    z-index: 18;
-}
-
-.group:nth-child(4) .group__header {
-    z-index: 17;
-}
-
-.group:nth-child(5) .group__header {
-    z-index: 16;
-}
-
-.group:nth-child(6) .group__header {
-    z-index: 15;
-}
-
-.group:nth-child(7) .group__header {
-    z-index: 14;
-}
-
-.group:nth-child(8) .group__header {
-    z-index: 13;
-}
-
-.group:nth-child(9) .group__header {
-    z-index: 12;
-}
-
-.group:nth-child(10) .group__header {
-    z-index: 11;
 }
 
 .group__icon {

--- a/src/views/news/index.phtml
+++ b/src/views/news/index.phtml
@@ -13,193 +13,195 @@
 </div>
 
 <?php if (!$links_timeline->empty()): ?>
-    <?php foreach ($links_timeline->datesGroups() as $date_group): ?>
-        <section class="group">
-            <header class="group__header">
-                <h2 class="group__title">
-                    <?= _date($date_group->date, 'dd MMMM') ?>
+    <div data-controller="zindex-inverser">
+        <?php foreach ($links_timeline->datesGroups() as $date_group): ?>
+            <section class="group">
+                <header class="group__header" data-zindex-inverser-target="item">
+                    <h2 class="group__title">
+                        <?= _date($date_group->date, 'dd MMMM') ?>
 
-                    <?php if ($date_group->isToday()): ?>
-                        <small class="text--secondary">⋅ <?= _('today') ?></small>
-                    <?php elseif ($date_group->isYesterday()): ?>
-                        <small class="text--secondary">⋅ <?= _('yesterday') ?></small>
-                    <?php endif; ?>
-                </h2>
+                        <?php if ($date_group->isToday()): ?>
+                            <small class="text--secondary">⋅ <?= _('today') ?></small>
+                        <?php elseif ($date_group->isYesterday()): ?>
+                            <small class="text--secondary">⋅ <?= _('yesterday') ?></small>
+                        <?php endif; ?>
+                    </h2>
 
-                <div class="group__separator"></div>
+                    <div class="group__separator"></div>
 
-                <details
-                    class="popup"
-                    data-controller="popup"
-                    data-action="toggle->popup#update click@window->popup#closeOnClickOutside keydown->popup#closeOnEscape"
-                >
-                    <summary class="popup__opener">
-                        <span class="button button--small button--ghost">
-                            <?= icon('menu') ?>
+                    <details
+                        class="popup"
+                        data-controller="popup"
+                        data-action="toggle->popup#update click@window->popup#closeOnClickOutside keydown->popup#closeOnEscape"
+                    >
+                        <summary class="popup__opener">
+                            <span class="button button--small button--ghost">
+                                <?= icon('menu') ?>
 
-                            <span class="no-mobile">
-                                <?= _('Actions') ?>
-                            </span>
-                        </span>
-                    </summary>
-
-                    <nav class="popup__container popup__container--left" role="menu">
-                        <div class="popup__title"><?= _('Actions on the day') ?></div>
-
-                        <form method="post" action="<?= url('mark collection as read', ['id' => $news->id]) ?>" role="menuitem">
-                            <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                            <input type="hidden" name="from" value="<?= url('news') ?>" />
-                            <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-
-                            <button class="popup__item popup__item--button">
-                                <?= icon('check') ?>
-                                <?= _('Mark all as read') ?>
-                            </button>
-                        </form>
-
-                        <form method="post" action="<?= url('read collection later', ['id' => $news->id]) ?>" role="menuitem">
-                            <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                            <input type="hidden" name="from" value="<?= url('news') ?>" />
-                            <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-
-                            <button class="popup__item popup__item--button">
-                                <?= icon('bookmark') ?>
-                                <?= _('Read the links later') ?>
-                            </button>
-                        </form>
-
-                        <div class="popup__separator"></div>
-
-                        <form
-                            method="post"
-                            action="<?= url('never read collection', ['id' => $news->id]) ?>"
-                            data-turbo-confirm="<?= _('You’ll remove all the news links, this action cannot be canceled. Are you sure?') ?>"
-                            role="menuitem"
-                        >
-                            <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                            <input type="hidden" name="from" value="<?= url('news') ?>" />
-                            <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-
-                            <button class="popup__item popup__item--button">
-                                <?= icon('times') ?>
-                                <?= _('Remove the links from the news') ?>
-                            </button>
-                        </form>
-                    </nav>
-                </details>
-            </header>
-
-            <div class="cards">
-                <?php foreach ($date_group->links as $link): ?>
-                    <?= $this->include('links/_link.phtml', [
-                        'link' => $link,
-                        'from' => \Minz\Url::for('news'),
-                        'display_edit' => true,
-                        'display_repair' => true,
-                        'display_source' => true,
-                        'display_read_later' => true,
-                        'display_mark_as_read' => true,
-                        'display_never' => true,
-                        'storing_must_mark_as_read' => true,
-                    ]); ?>
-                <?php endforeach; ?>
-            </div>
-
-            <?php foreach ($date_group->sourceGroups() as $source_group): ?>
-                <div class="news__source-group">
-                    <div class="line">
-                        <h3 class="news__source-title">
-                            <?= protect($source_group->title) ?>
-
-                            <small class="text--secondary">
-                                ⋅ <?= _nf('%s link', '%s links', count($source_group->links), count($source_group->links)) ?>
-                            </small>
-                        </h3>
-
-                        <details
-                            class="popup"
-                            data-controller="popup"
-                            data-action="toggle->popup#update click@window->popup#closeOnClickOutside keydown->popup#closeOnEscape"
-                        >
-                            <summary class="popup__opener">
-                                <span class="button button--smaller button--ghost">
-                                    <?= icon('menu') ?>
-
-                                    <span class="sr-only">
-                                        <?= _('Actions') ?>
-                                    </span>
+                                <span class="no-mobile">
+                                    <?= _('Actions') ?>
                                 </span>
-                            </summary>
+                            </span>
+                        </summary>
 
-                            <nav class="popup__container popup__container--left" role="menu">
-                                <div class="popup__title"><?= _('Actions on the feed') ?></div>
+                        <nav class="popup__container popup__container--left" role="menu">
+                            <div class="popup__title"><?= _('Actions on the day') ?></div>
 
-                                <form data-turbo-preserve-scroll method="post" action="<?= url('mark collection as read', ['id' => $news->id]) ?>" role="menuitem">
-                                    <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                                    <input type="hidden" name="from" value="<?= url('news') ?>" />
-                                    <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-                                    <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+                            <form method="post" action="<?= url('mark collection as read', ['id' => $news->id]) ?>" role="menuitem">
+                                <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
 
-                                    <button class="popup__item popup__item--button">
-                                        <?= icon('check') ?>
-                                        <?= _('Mark all as read') ?>
-                                    </button>
-                                </form>
+                                <button class="popup__item popup__item--button">
+                                    <?= icon('check') ?>
+                                    <?= _('Mark all as read') ?>
+                                </button>
+                            </form>
 
-                                <form data-turbo-preserve-scroll method="post" action="<?= url('read collection later', ['id' => $news->id]) ?>" role="menuitem">
-                                    <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                                    <input type="hidden" name="from" value="<?= url('news') ?>" />
-                                    <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-                                    <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+                            <form method="post" action="<?= url('read collection later', ['id' => $news->id]) ?>" role="menuitem">
+                                <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
 
-                                    <button class="popup__item popup__item--button">
-                                        <?= icon('bookmark') ?>
-                                        <?= _('Read the links later') ?>
-                                    </button>
-                                </form>
+                                <button class="popup__item popup__item--button">
+                                    <?= icon('bookmark') ?>
+                                    <?= _('Read the links later') ?>
+                                </button>
+                            </form>
 
-                                <div class="popup__separator"></div>
+                            <div class="popup__separator"></div>
 
-                                <form
-                                    data-turbo-preserve-scroll
-                                    method="post"
-                                    action="<?= url('never read collection', ['id' => $news->id]) ?>"
-                                    data-turbo-confirm="<?= _('You’ll remove all the news links, this action cannot be canceled. Are you sure?') ?>"
-                                    role="menuitem"
-                                >
-                                    <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
-                                    <input type="hidden" name="from" value="<?= url('news') ?>" />
-                                    <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
-                                    <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+                            <form
+                                method="post"
+                                action="<?= url('never read collection', ['id' => $news->id]) ?>"
+                                data-turbo-confirm="<?= _('You’ll remove all the news links, this action cannot be canceled. Are you sure?') ?>"
+                                role="menuitem"
+                            >
+                                <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
 
-                                    <button class="popup__item popup__item--button">
-                                        <?= icon('times') ?>
-                                        <?= _('Remove the links from the news') ?>
-                                    </button>
-                                </form>
-                            </nav>
-                        </details>
-                    </div>
+                                <button class="popup__item popup__item--button">
+                                    <?= icon('times') ?>
+                                    <?= _('Remove the links from the news') ?>
+                                </button>
+                            </form>
+                        </nav>
+                    </details>
+                </header>
 
-                    <div class="cards">
-                        <?php foreach ($source_group->links as $link): ?>
-                            <?= $this->include('links/_link.phtml', [
-                                'link' => $link,
-                                'from' => \Minz\Url::for('news'),
-                                'display_edit' => true,
-                                'display_repair' => true,
-                                'display_source' => true,
-                                'display_read_later' => true,
-                                'display_mark_as_read' => true,
-                                'display_never' => true,
-                                'storing_must_mark_as_read' => true,
-                            ]); ?>
-                        <?php endforeach; ?>
-                    </div>
+                <div class="cards">
+                    <?php foreach ($date_group->links as $link): ?>
+                        <?= $this->include('links/_link.phtml', [
+                            'link' => $link,
+                            'from' => \Minz\Url::for('news'),
+                            'display_edit' => true,
+                            'display_repair' => true,
+                            'display_source' => true,
+                            'display_read_later' => true,
+                            'display_mark_as_read' => true,
+                            'display_never' => true,
+                            'storing_must_mark_as_read' => true,
+                        ]); ?>
+                    <?php endforeach; ?>
                 </div>
-            <?php endforeach; ?>
-        </section>
-    <?php endforeach; ?>
+
+                <?php foreach ($date_group->sourceGroups() as $source_group): ?>
+                    <div class="news__source-group">
+                        <div class="line">
+                            <h3 class="news__source-title">
+                                <?= protect($source_group->title) ?>
+
+                                <small class="text--secondary">
+                                    ⋅ <?= _nf('%s link', '%s links', count($source_group->links), count($source_group->links)) ?>
+                                </small>
+                            </h3>
+
+                            <details
+                                class="popup"
+                                data-controller="popup"
+                                data-action="toggle->popup#update click@window->popup#closeOnClickOutside keydown->popup#closeOnEscape"
+                            >
+                                <summary class="popup__opener">
+                                    <span class="button button--smaller button--ghost">
+                                        <?= icon('menu') ?>
+
+                                        <span class="sr-only">
+                                            <?= _('Actions') ?>
+                                        </span>
+                                    </span>
+                                </summary>
+
+                                <nav class="popup__container popup__container--left" role="menu">
+                                    <div class="popup__title"><?= _('Actions on the feed') ?></div>
+
+                                    <form data-turbo-preserve-scroll method="post" action="<?= url('mark collection as read', ['id' => $news->id]) ?>" role="menuitem">
+                                        <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                        <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                        <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
+                                        <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+
+                                        <button class="popup__item popup__item--button">
+                                            <?= icon('check') ?>
+                                            <?= _('Mark all as read') ?>
+                                        </button>
+                                    </form>
+
+                                    <form data-turbo-preserve-scroll method="post" action="<?= url('read collection later', ['id' => $news->id]) ?>" role="menuitem">
+                                        <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                        <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                        <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
+                                        <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+
+                                        <button class="popup__item popup__item--button">
+                                            <?= icon('bookmark') ?>
+                                            <?= _('Read the links later') ?>
+                                        </button>
+                                    </form>
+
+                                    <div class="popup__separator"></div>
+
+                                    <form
+                                        data-turbo-preserve-scroll
+                                        method="post"
+                                        action="<?= url('never read collection', ['id' => $news->id]) ?>"
+                                        data-turbo-confirm="<?= _('You’ll remove all the news links, this action cannot be canceled. Are you sure?') ?>"
+                                        role="menuitem"
+                                    >
+                                        <input type="hidden" name="csrf" value="<?= $csrf_token ?>" />
+                                        <input type="hidden" name="from" value="<?= url('news') ?>" />
+                                        <input type="hidden" name="date" value="<?= $date_group->date->format('Y-m-d') ?>" />
+                                        <input type="hidden" name="source" value="<?= $source_group->reference ?>" />
+
+                                        <button class="popup__item popup__item--button">
+                                            <?= icon('times') ?>
+                                            <?= _('Remove the links from the news') ?>
+                                        </button>
+                                    </form>
+                                </nav>
+                            </details>
+                        </div>
+
+                        <div class="cards">
+                            <?php foreach ($source_group->links as $link): ?>
+                                <?= $this->include('links/_link.phtml', [
+                                    'link' => $link,
+                                    'from' => \Minz\Url::for('news'),
+                                    'display_edit' => true,
+                                    'display_repair' => true,
+                                    'display_source' => true,
+                                    'display_read_later' => true,
+                                    'display_mark_as_read' => true,
+                                    'display_never' => true,
+                                    'storing_must_mark_as_read' => true,
+                                ]); ?>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </section>
+        <?php endforeach; ?>
+    </div>
 
     <div class="news__postpone">
         <details


### PR DESCRIPTION
The previous hack didn't work as expected for the collections and feeds groups. After a certain number of groups, the header passed behind the cards.

There is still an issue on mobile: if you open the actions menu of a date group (not the first) and that you scroll up, the menu will appear behind the headers. That's however a bit less problematic. Also, I plan to change the popups behaviour by not fixing them to the screen.

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
