### PR TITLE
fix: Generate correct links to tags in Atom feeds

### DIFF
--- a/src/utils/MiniMarkdown.php
+++ b/src/utils/MiniMarkdown.php
@@ -64,7 +64,7 @@ class MiniMarkdown extends \Parsedown
 
         if ($result) {
             $tag = $matches['tag'];
-            $tag_url = \Minz\Url::for('links', [
+            $tag_url = \Minz\Url::absoluteFor('links', [
                 'q' => "#{$tag}",
             ]);
 


### PR DESCRIPTION
In the feeds, the links to tags were in the form of `/links?q=#tag`. Most of the aggregators are able to rebuild the correct link by using the feed domain as the base URL. But it didn't work when the feeds were generated with the `direct=true` parameter because the base URL wasn't the one to Flus.

Now, the tags links are always generated in an absolute form to avoid this issue (even in the interface because it was easier to patch).

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
