### PR TITLE
fix: Allow to setup Flus if the database already exists

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,12 +62,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/flusio/Minz.git",
-                "reference": "7cf8c393a2fc23fb8cce7365e4644e89ecacafca"
+                "reference": "019ce2b68c64fa173f126d4a58ff41b15bc15252"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flusio/Minz/zipball/7cf8c393a2fc23fb8cce7365e4644e89ecacafca",
-                "reference": "7cf8c393a2fc23fb8cce7365e4644e89ecacafca",
+                "url": "https://api.github.com/repos/flusio/Minz/zipball/019ce2b68c64fa173f126d4a58ff41b15bc15252",
+                "reference": "019ce2b68c64fa173f126d4a58ff41b15bc15252",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 "issues": "https://github.com/flusio/Minz/issues",
                 "source": "https://github.com/flusio/Minz/tree/main"
             },
-            "time": "2025-01-23T09:47:25+00:00"
+            "time": "2025-01-23T14:16:31+00:00"
         },
         {
             "name": "phpmailer/phpmailer",


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/flusio/Flus/issues/643

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Start Flus in a clean state (`make docker-clean && rm data/migrations_version.txt`)
2. Create the database: `./docker/bin/psql` and `CREATE DATABASE flus_development;`)
3. Setup the database: `make db-setup`
4. Verify that it works

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
