### PR TITLE
cli: Add a command to import a Pocket CSV file

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -299,6 +299,8 @@ class Router
         $router->addRoute('CLI', '/jobs/unfail', 'Jobs#unfail');
         $router->addRoute('CLI', '/jobs/unlock', 'Jobs#unlock');
 
+        $router->addRoute('CLI', '/pocket/import', 'Pocket#import');
+
         return $router;
     }
 }

--- a/src/cli/Pocket.php
+++ b/src/cli/Pocket.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\cli;
+
+use App\models;
+use App\utils;
+use Minz\Request;
+use Minz\Response;
+
+/**
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class Pocket
+{
+    /**
+     * @request_param string user
+     * @request_param string file
+     * @request_param bool import-read-later
+     */
+    public function import(Request $request): Response
+    {
+        $user_id = $request->parameters->getString('user', '');
+        $filename = $request->parameters->getString('file', '');
+        $import_read_later = $request->parameters->getBoolean('import-read-later');
+
+        $user = models\User::find($user_id);
+
+        if (!$user) {
+            return Response::text(400, 'User does not exist.');
+        }
+
+        utils\Locale::setCurrentLocale($user->locale);
+
+        $file = fopen(getcwd() . '/' . $filename, 'r');
+
+        if (!$file) {
+            return Response::text(400, 'Cannot open the file.');
+        }
+
+        $items = [];
+
+        while (($row = fgetcsv($file, escape: '')) !== false) {
+            if ($row[0] === 'title') {
+                continue;
+            }
+
+            $items[] = [
+                'title' => $row[0] ?? '',
+                'url' => $row[1] ?? '',
+                'time_added' => $row[2] ?? '',
+                'tags' => $row[3] ?? '',
+                'status' => $row[4] ?? '',
+            ];
+        }
+
+        fclose($file);
+
+        $this->importPocketItems($user, $items, $import_read_later);
+
+        return Response::text(200, 'Importation finished.');
+    }
+
+    /**
+     * @param array<array{
+     *     title: string,
+     *     url: string,
+     *     time_added: string,
+     *     tags: string,
+     *     status: string,
+     * }> $items
+     */
+    public function importPocketItems(models\User $user, array $items, bool $import_read_later): void
+    {
+        $bookmarks_collection = $user->bookmarks();
+        $pocket_collection = models\Collection::findOrCreateBy([
+            'name' => _('Pocket links'),
+            'user_id' => $user->id,
+        ], [
+            'id' => \Minz\Random::timebased(),
+            'description' => _('All your links imported from Pocket.'),
+        ]);
+
+        // This will be used to check if URL has already been added by the user
+        $link_ids_by_urls = models\Link::listUrlsToIdsByUserId($user->id);
+
+        // This will store the items that we effectively need to create. We
+        // don't create links, collections and their relation on the fly because
+        // it would be too intensive. We rather prefer to insert them all at
+        // once (see calls to `bulkInsert` below).
+        $links_to_create = [];
+        $links_to_collections_to_create = [];
+        $notes = [];
+
+        foreach ($items as $item) {
+            $url = $item['url'];
+
+            if (!\SpiderBits\Url::isValid($url)) {
+                continue;
+            }
+
+            $collection_ids = [];
+            $collection_ids[] = $pocket_collection->id;
+            if ($item['status'] === 'unread' && $import_read_later) {
+                $collection_ids[] = $bookmarks_collection->id;
+            }
+
+            $tags = explode('|', $item['tags']);
+            $tags = array_map(function (string $tag): string {
+                $tag = trim($tag);
+                $tag = str_replace(' ', '_', $tag);
+                return $tag;
+            }, $tags);
+            $tags = array_filter($tags);
+
+            if (isset($link_ids_by_urls[$url])) {
+                $link_id = $link_ids_by_urls[$url];
+            } else {
+                // The user didn't added this link yet, so we'll need to create
+                // it. First, initiate a new model
+                $link = new models\Link($url, $user->id, false);
+
+                if ($item['title']) {
+                    $link->title = $item['title'];
+                }
+
+                $link->setTags($tags);
+
+                // In normal cases, created_at is set on save() call. Since we
+                // add links via the bulkInsert call, we have to set created_at
+                // first, or it would fail because of the not-null constraint.
+                $link->created_at = \Minz\Time::now();
+
+                $links_to_create[] = $link;
+
+                $link_ids_by_urls[$link->url] = $link->id;
+                $link_id = $link->id;
+            }
+
+            $timestamp = intval($item['time_added']);
+
+            $published_at = null;
+            if ($timestamp > 0) {
+                $published_at = \DateTimeImmutable::createFromFormat('U', (string) $timestamp);
+            }
+
+            if (!$published_at) {
+                $published_at = \Minz\Time::now();
+            }
+
+            // We now have a link_id and a list of collection ids. We store
+            // here the relations in the last _to_create array.
+            foreach ($collection_ids as $collection_id) {
+                $link_to_collection = new models\LinkToCollection($link_id, $collection_id);
+                $link_to_collection->created_at = $published_at;
+                $links_to_collections_to_create[] = $link_to_collection;
+            }
+
+            // We create a note containing the list of tags if any.
+            if (count($tags) > 0) {
+                $formatted_tags = array_map(function (string $tag): string {
+                    return "#{$tag}";
+                }, $tags);
+
+                $content = implode(' ', $formatted_tags);
+
+                $note = new models\Note($user->id, $link_id, $content);
+                $note->created_at = $published_at;
+
+                $notes[] = $note;
+            }
+        }
+
+        // Finally, let the big import (in DB) begin!
+        models\Link::bulkInsert($links_to_create);
+        models\LinkToCollection::bulkInsert($links_to_collections_to_create);
+        models\Note::bulkInsert($notes);
+
+        // Delete the collections if they are empty at the end of the
+        // importation.
+        $count_pocket_links = models\Link::countByCollectionId($pocket_collection->id);
+        if ($count_pocket_links === 0) {
+            $pocket_collection->remove();
+        }
+    }
+}


### PR DESCRIPTION
This is not an official feature, just a way to temporarily import Pocket CSV exports manually without spending too much time on the feature.

Later, I'd like to develop an interface to import more types of files.

## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

N/A

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Accessibility has been tested
- [ ] Translations are synchronized
- [ ] The API provides the corresponding endpoints / data
- [ ] Tests are up to date
- [ ] Copyright notices are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
