### PR TITLE
fix: Check that Mastodon account is setup when checking user authorization

### DIFF
--- a/src/models/User.php
+++ b/src/models/User.php
@@ -795,9 +795,11 @@ class User
     public function isMastodonEnabled(): bool
     {
         return $this->memoize('is_mastodon_enabled', function (): bool {
-            return MastodonAccount::existsBy([
+            $mastodon_account = MastodonAccount::findBy([
                 'user_id' => $this->id,
             ]);
+
+            return $mastodon_account && $mastodon_account->isSetup();
         });
     }
 


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Setup a Mastodon account
2. Update the access_token to empty string
3. Check that the Mastodon sharing button doesn't appear in the interface

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
