### PR TITLE
fix: Don't escape html title twice

### DIFF
--- a/src/views/layouts/_title.html.twig
+++ b/src/views/layouts/_title.html.twig
@@ -9,4 +9,6 @@
     {%- set title = '[dev] ' ~ title -%}
 {%- endif -%}
 {%- set title = title ~ ' · ' ~ app.brand -%}
-{{- title -}}
+{# It is fine to render raw title as the content is passed from a block which
+ # is already escaped. This avoids to escape title twice. #}
+{{- title | raw -}}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a collection containing the character `'`
2. Check in the browser tab that the character appears correctly (and not as `&#039;`)

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
