### PR TITLE
feat: Improve duration detection using JSON+LD

### DIFF
--- a/lib/SpiderBits/src/DomExtractor.php
+++ b/lib/SpiderBits/src/DomExtractor.php
@@ -138,16 +138,25 @@ class DomExtractor
         // @see https://schema.org/docs/gs.html
         $duration_node = $dom->select('//*[@itemprop = "duration"]/attribute::content');
 
+        $duration_text = '';
+
         if ($duration_node) {
+            $duration_text = $duration_node->text();
+        } else {
+            $duration_text = self::extractDurationFromJsonLd($dom);
+        }
+
+        if ($duration_text) {
             try {
-                $interval = new \DateInterval($duration_node->text());
+                $interval = new \DateInterval($duration_text);
                 // Convert the interval to minutes
                 $duration = $interval->y * 12 * 30 * 24 * 60;
                 $duration += $interval->m * 30 * 24 * 60;
                 $duration += $interval->d * 24 * 60;
                 $duration += $interval->h * 60;
                 $duration += $interval->i;
-                if ($interval->s >= 30) {
+                $duration += intval($interval->s / 60);
+                if ($interval->s % 60 >= 30) {
                     $duration += 1;
                 }
                 return $duration;
@@ -156,8 +165,9 @@ class DomExtractor
             }
         }
 
-        // If there is no duration node (or if its content can't be parsed),
-        // roughly estimate the duration from the DOM content.
+        // If we didn't detect a duration indication (or if the duration
+        // content can't be parsed), roughly estimate the duration from the DOM
+        // content.
         $content = self::content($dom);
         $words = array_filter(explode(' ', $content));
         $average_reading_speed = 200;
@@ -188,5 +198,31 @@ class DomExtractor
         }
 
         return $feeds;
+    }
+
+    private static function extractDurationFromJsonLd(Dom $dom): string
+    {
+        $json_ld_nodes = $dom->select('//script[@type = "application/ld+json"]');
+
+        if (!$json_ld_nodes) {
+            return '';
+        }
+
+        foreach ($json_ld_nodes->list() as $json_ld_node) {
+            $json = json_decode(trim($json_ld_node->textContent), associative: true);
+
+            if (!is_array($json)) {
+                continue;
+            }
+
+            $json_ld = new JsonLd($json);
+            $duration_text = $json_ld->duration();
+
+            if ($duration_text) {
+                return $duration_text;
+            }
+        }
+
+        return '';
     }
 }

--- a/lib/SpiderBits/src/JsonLd.php
+++ b/lib/SpiderBits/src/JsonLd.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SpiderBits;
+
+/**
+ * This class helps to deal with json+ld contents. Note this is NOT a fully
+ * operational json+ld library.
+ *
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class JsonLd
+{
+    public function __construct(
+        /** @var mixed[] $json */
+        private array $json
+    ) {
+    }
+
+    public function duration(): string
+    {
+        return $this->durationFromNode($this->json);
+    }
+
+    /**
+     * @param mixed[] $node
+     */
+    private function durationFromNode(array $node): string
+    {
+        $duration_text = $node['duration'] ?? null;
+
+        if (is_string($duration_text)) {
+            return $duration_text;
+        }
+
+        $mainEntity = $node['mainEntity'] ?? null;
+
+        if (is_array($mainEntity)) {
+            return self::durationFromNode($mainEntity);
+        }
+
+        foreach ($this->graph($node) as $child_node) {
+            if (!is_array($child_node)) {
+                continue;
+            }
+
+            $duration = $this->durationFromNode($child_node);
+
+            if ($duration) {
+                return $duration;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param mixed[] $node
+     * @return mixed[]
+     */
+    private function graph(array $node): array
+    {
+        $graph = $node['@graph'] ?? null;
+
+        if (!is_array($graph)) {
+            return [];
+        }
+
+        return $graph;
+    }
+}

--- a/tests/lib/SpiderBits/DomExtractorTest.php
+++ b/tests/lib/SpiderBits/DomExtractorTest.php
@@ -343,6 +343,58 @@ class DomExtractorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(2, $duration);
     }
 
+    public function testDurationWithJsonLdDurationAttribute(): void
+    {
+        /** @var string */
+        $content = $this->fake('words', 400, true);
+        $dom = Dom::fromText(<<<HTML
+            <html>
+                <body>
+                    <script type="application/ld+json">
+                        {
+                            "@context": "http://schema.org",
+                            "@type": "VideoObject",
+                            "name": "My video",
+                            "url": "https://videos.example.com/my-video",
+                            "duration": "PT2520S"
+                        }
+                    </script>
+
+                    <main>
+                        {$content}
+                    </main>
+                </body>
+            </html>
+        HTML);
+
+        $duration = DomExtractor::duration($dom);
+
+        $this->assertSame(42, $duration);
+    }
+
+    public function testDurationWithInvalidJsonLd(): void
+    {
+        /** @var string */
+        $content = $this->fake('words', 400, true);
+        $dom = Dom::fromText(<<<HTML
+            <html>
+                <body>
+                    <script type="application/ld+json">
+                        Not JSON+LD
+                    </script>
+
+                    <main>
+                        {$content}
+                    </main>
+                </body>
+            </html>
+        HTML);
+
+        $duration = DomExtractor::duration($dom);
+
+        $this->assertSame(2, $duration);
+    }
+
     public function testFeeds(): void
     {
         $dom = Dom::fromText(<<<HTML

--- a/tests/lib/SpiderBits/JsonLdTest.php
+++ b/tests/lib/SpiderBits/JsonLdTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SpiderBits;
+
+class JsonLdTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDurationWithRootAttribute(): void
+    {
+        $json_ld_array = [
+            '@context' => 'http://schema.org',
+            '@type' => 'VideoObject',
+            'name' => 'My video',
+            'url' => 'https://videos.example.com/my-video',
+            'duration' => 'PT2520',
+        ];
+        $json_ld = new JsonLd($json_ld_array);
+
+        $duration = $json_ld->duration();
+
+        $this->assertSame('PT2520', $duration);
+    }
+
+    public function testDurationInMainEntity(): void
+    {
+        $json_ld_array = [
+            '@context' => 'http://schema.org',
+            '@type' => 'RadioEpisode',
+            'mainEntity' => [
+                '@type' => 'AudioObject',
+                'contentUrl' => 'https://radio.example.com/episode',
+                'duration' => 'PT2520',
+            ],
+        ];
+
+        $json_ld = new JsonLd($json_ld_array);
+
+        $duration = $json_ld->duration();
+
+        $this->assertSame('PT2520', $duration);
+    }
+
+    public function testDurationInGraphAttribute(): void
+    {
+        $json_ld_array = [
+            '@context' => 'http://schema.org',
+            '@graph' => [
+                [
+                    '@type' => 'VideoObject',
+                    'name' => 'My video',
+                    'url' => 'https://videos.example.com/my-video',
+                    'duration' => 'PT2520',
+                ],
+            ],
+        ];
+        $json_ld = new JsonLd($json_ld_array);
+
+        $duration = $json_ld->duration();
+
+        $this->assertSame('PT2520', $duration);
+    }
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Add a link to some site providing duration as json+ld content (e.g. https://www.radiofrance.fr/franceinter/podcasts/net-plus-ultra/net-plus-ultra-du-vendredi-03-avril-2026-3032941)
2. Verify the duration is correct in Flus

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
