### PR TITLE
fix: Don't duplicate link when repairing with the same url

### DIFF
--- a/src/controllers/links/Repairing.php
+++ b/src/controllers/links/Repairing.php
@@ -94,7 +94,13 @@ class Repairing extends BaseController
             ]);
         }
 
-        $old_link = models\Link::copy($link, $user->id);
+        if ($link->url !== $form->url) {
+            // Add the old link to the never list. It avoids to a link coming from
+            // the news to reappear.
+            $old_link = models\Link::copy($link, $user->id);
+            $old_link->save();
+            $user->removeFromJournal($old_link);
+        }
 
         $link->url = $form->url;
 
@@ -112,11 +118,6 @@ class Repairing extends BaseController
         }
 
         $link->save();
-
-        // Add the old link to the never list. It avoids to a link coming from
-        // the news to reappear.
-        $old_link->save();
-        $user->removeFromJournal($old_link);
 
         return Response::found(utils\RequestHelper::from($request));
     }

--- a/tests/controllers/links/RepairingTest.php
+++ b/tests/controllers/links/RepairingTest.php
@@ -213,11 +213,41 @@ class RepairingTest extends \PHPUnit\Framework\TestCase
         ]);
         $never_list = $user->neverList();
         $this->assertNotNull($link);
-        $link_to_never_list = models\LinkToCollection::findBy([
+        $is_in_never_list = models\LinkToCollection::existsBy([
             'link_id' => $link->id,
             'collection_id' => $never_list->id,
         ]);
-        $this->assertNotNull($link_to_never_list);
+        $this->assertTrue($is_in_never_list);
+    }
+
+    public function testCreateDoesNotAddTheUrlToTheNeverListIfNotChanged(): void
+    {
+        $user = $this->login();
+        /** @var string */
+        $url = $this->fakeUnique('url');
+        $link = LinkFactory::create([
+            'user_id' => $user->id,
+            'url' => $url,
+        ]);
+        $this->mockHttpWithFixture($url, 'responses/flus.fr_carnet_index.html');
+
+        $response = $this->appRun('POST', "/links/{$link->id}/repair", [
+            'url' => $url,
+            'csrf_token' => $this->csrfToken(forms\links\RepairLink::class),
+        ]);
+
+        $this->assertResponseCode($response, 302, "/links/{$link->id}/repair");
+        $count_links = models\Link::countBy([
+            'user_id' => $user->id,
+            'url' => $url,
+        ]);
+        $this->assertSame(1, $count_links);
+        $never_list = $user->neverList();
+        $is_in_never_list = models\LinkToCollection::existsBy([
+            'link_id' => $link->id,
+            'collection_id' => $never_list->id,
+        ]);
+        $this->assertFalse($is_in_never_list);
     }
 
     public function testCreateRedirectsIfNotConnected(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Add a link
2. Repair the link without changing the url
3. Verify in the database that the link url is not duplicated

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
