### PR TITLE
fix: Group and mark links by sources in the news

### DIFF
--- a/docs/api/journal.md
+++ b/docs/api/journal.md
@@ -29,7 +29,7 @@ $ curl -H "Content-Type: application/json" \
         "is_hidden": false,
         "reading_time": 3,
         "tags": [],
-        "source": "collection#<id>",
+        "source": "<id>",
         "origin": {
             "value": "https://app.flus.fr/collections/<id>",
             "label": "<collection's name>",
@@ -55,7 +55,8 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: `origin` is added
+- 2.5.0: `source` format changed from `<source type>#<source id>` to `<source id>`
 
 ## Refresh the journal
 
@@ -103,8 +104,7 @@ POST /api/v1/journal/read
 ### JSON Parameters
 
 - `date` (string, optional, format: `YYYY-MM-DD`): a date to filter the links to mark as read
-- `origin` (string, optional): an origin to filter the links to mark as read
-- `source` (**deprecated,** string, optional): a source to filter the links to mark as read
+- `source` (string, optional): a source to filter the links to mark as read
 
 ### Example
 
@@ -135,7 +135,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: old `source` format (e.g. `collection#<id>`) is deprecated, use `<id>` format instead
 
 ## Mark the links of the journal to read later
 
@@ -146,8 +146,7 @@ POST /api/v1/journal/later
 ### JSON Parameters
 
 - `date` (string, optional, format: `YYYY-MM-DD`): a date to filter the links to mark to read later
-- `origin` (string, optional): an origin to filter the links to mark to read later
-- `source` (**deprecated,** string, optional): a source to filter the links to mark to read later
+- `source` (string, optional): a source to filter the links to mark to read later
 
 ### Example
 
@@ -178,7 +177,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: old `source` format (e.g. `collection#<id>`) is deprecated, use `<id>` format instead
 
 ## Remove the links from the journal
 
@@ -189,8 +188,7 @@ DELETE /api/v1/journal/links
 ### JSON Parameters
 
 - `date` (string, optional, format: `YYYY-MM-DD`): a date to filter the links to remove
-- `origin` (string, optional): an origin to filter the links to remove
-- `source` (**deprecated,** string, optional): a source to filter the links to remove
+- `source` (string, optional): a source to filter the links to remove
 
 ### Example
 
@@ -221,7 +219,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: old `source` format (e.g. `collection#<id>`) is deprecated, use `<id>` format instead
 
 ## Remove a single link from the journal
 

--- a/docs/api/links.md
+++ b/docs/api/links.md
@@ -81,7 +81,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: `origin` added
 
 ## Get a link
 
@@ -148,7 +148,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: `origin` added
 
 ## Update a link
 
@@ -160,6 +160,8 @@ PATCH /api/v1/links/:id
 
 - `title` (string, optional): the title of the link
 - `reading_time` (integer, optional): the reading time of the link, in minutes
+- `origin` (string, optional): the origin of the link, URL preferred
+- `origin_is_public` (boolean, optional): whether the origin of the link is public or not
 
 ### Example
 
@@ -249,8 +251,7 @@ $ curl -H "Content-Type: application/json" \
 ### Changelog
 
 - 2.0.0: added
-- 2.5.0: `origin` and `origin_is_public` can be updated
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: `origin` and `origin_is_public` added
 
 ## Delete a link
 

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -90,4 +90,4 @@ Thus, you can follow feeds using the same endpoint as for the collections.
 - 2.0.0: added
 - 2.0.5: add missing `created_at`, `is_hidden`, `source`, `published_at`, `number_notes`
 - 2.0.5: `feeds` entry added
-- 2.5.0: `source` is deprecated, use `origin` instead
+- 2.5.0: `origin` added to links

--- a/src/assets/stylesheets/components/groups.css
+++ b/src/assets/stylesheets/components/groups.css
@@ -36,7 +36,7 @@
     padding-left: var(--space-smaller);
 }
 
-.origin-group__title {
+.source-group__title {
     font-size: var(--font-size-normal);
     font-weight: 600;
 }

--- a/src/forms/api/EmptyJournal.php
+++ b/src/forms/api/EmptyJournal.php
@@ -15,9 +15,6 @@ class EmptyJournal extends Form
     public ?\DateTimeImmutable $date = null;
 
     #[Form\Field]
-    public ?string $origin = null;
-
-    #[Form\Field]
     public ?string $source = null;
 
     private models\User $user;
@@ -39,32 +36,44 @@ class EmptyJournal extends Form
             $options['published_date'] = $this->date;
         }
 
-        // @deprecated Can be removed in version 3.0.0.
-        $source_origin = $this->sourceToOrigin();
-        if ($source_origin) {
-            $options['origin'] = $source_origin;
-        }
-
-        if ($this->origin) {
-            $options['origin'] = $this->origin;
+        $source = $this->normalizedSource();
+        if ($source) {
+            $options['source'] = $source;
         }
 
         $news = $this->user->news();
         return $news->links(options: $options);
     }
 
-    public function sourceToOrigin(): ?string
+    /**
+     * Return the normalized source.
+     *
+     * Before Flus 2.5.0, sources followed the format "<source type>#<source id>",
+     * where "source type" could either be "user" or "collection". Since Flus
+     * 2.5.0, only "collection" source are supported. Thus, the source only
+     * contains the id of the collection.
+     *
+     * This method enables to support both formats by always returning (only)
+     * the source id.
+     *
+     * @deprecated Can be removed in version 3.0.0.
+     */
+    public function normalizedSource(): ?string
     {
         if (!$this->source) {
             return null;
         }
 
+        if (!str_contains($this->source, '#')) {
+            return $this->source;
+        }
+
         list($source_type, $source_id) = explode('#', $this->source, 2);
 
-        return match ($source_type) {
-            'user' => \Minz\Url::absoluteFor('profile', ['id' => $source_id]),
-            'collection' => \Minz\Url::absoluteFor('collection', ['id' => $source_id]),
-            default => null,
-        };
+        if ($source_type !== 'collection') {
+            return null;
+        }
+
+        return $source_id;
     }
 }

--- a/src/forms/traits/CollectionLinks.php
+++ b/src/forms/traits/CollectionLinks.php
@@ -18,7 +18,7 @@ trait CollectionLinks
     public ?\DateTimeImmutable $date = null;
 
     #[Form\Field]
-    public string $origin = '';
+    public string $source = '';
 
     private string $from = '';
 
@@ -34,8 +34,8 @@ trait CollectionLinks
         if ($this->date) {
             $options['published_date'] = $this->date;
         }
-        if ($this->origin) {
-            $options['origin'] = $this->origin;
+        if ($this->source) {
+            $options['source'] = $this->source;
         }
 
         $options['hidden'] = auth\Access::can($user, 'viewHiddenLinks', $collection);

--- a/src/migrations/Migration202605270001AddSourceIdToLinks.php
+++ b/src/migrations/Migration202605270001AddSourceIdToLinks.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\migrations;
+
+class Migration202605270001AddSourceIdToLinks
+{
+    public function migrate(): bool
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            ALTER TABLE links
+            ADD COLUMN source_id TEXT REFERENCES collections ON DELETE SET NULL ON UPDATE CASCADE;
+
+            CREATE INDEX idx_links_source_id ON links(source_id) WHERE source_id IS NOT NULL;
+
+            DROP INDEX idx_links_origin;
+
+            UPDATE links
+            SET source_id = source_resource_id
+            WHERE source_type = 'collection'
+            AND EXISTS (
+                SELECT 1
+                FROM collections
+                WHERE id = source_resource_id
+            );
+        SQL);
+
+        return true;
+    }
+
+    public function rollback(): bool
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            CREATE INDEX idx_links_origin ON links(origin) WHERE origin != '';
+
+            DROP INDEX idx_links_source_id;
+
+            ALTER TABLE links
+            DROP COLUMN source_id;
+        SQL);
+
+        return true;
+    }
+}

--- a/src/models/Collection.php
+++ b/src/models/Collection.php
@@ -276,7 +276,7 @@ class Collection
      * @param string[] $selected_computed_props
      * @param array{
      *     'published_date'?: ?\DateTimeImmutable,
-     *     'origin'?: ?string,
+     *     'source'?: ?string,
      *     'hidden'?: bool,
      *     'offset'?: int,
      *     'limit'?: int|'ALL',

--- a/src/models/Journal.php
+++ b/src/models/Journal.php
@@ -29,12 +29,13 @@ class Journal
 
         foreach ($links as $news_link) {
             $link = $this->user->obtainLink($news_link);
+            $link->source_id = $news_link->source_id;
 
             // If the link has already an origin info, we want to keep it.
-            // Otherwise, we use the initial collection URL.
+            // Otherwise, we use the initial source URL.
             if (!$link->origin) {
                 $collection_url = \Minz\Url::absoluteFor('collection', [
-                    'id' => $news_link->initial_collection_id,
+                    'id' => $link->source_id,
                 ]);
                 $link->setOrigin($collection_url);
             }

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -85,6 +85,9 @@ class Link
     public ?string $feed_entry_id = null;
 
     #[Database\Column]
+    public ?string $source_id = null;
+
+    #[Database\Column]
     public string $source_type = '';
 
     #[Database\Column]
@@ -93,9 +96,6 @@ class Link
     /** @var string[] */
     #[Database\Column]
     public array $tags = [];
-
-    #[Database\Column(computed: true)]
-    public ?string $initial_collection_id = null;
 
     #[Database\Column(computed: true)]
     public ?\DateTimeImmutable $published_at = null;
@@ -167,7 +167,6 @@ class Link
         $link_copied->fetched_code = $link->fetched_code;
         $link_copied->fetched_count = $link->fetched_count;
         $link_copied->fetched_retry_at = $link->fetched_retry_at;
-        $link_copied->setOrigin('');
 
         return $link_copied;
     }
@@ -353,6 +352,17 @@ class Link
     }
 
     /**
+     * Return the source of the link.
+     */
+    public function source(): ?Collection
+    {
+        if (!$this->source_id) {
+            return null;
+        }
+        return Collection::find($this->source_id);
+    }
+
+    /**
      * Return whether or not the given user has the link URL in its news.
      */
     public function isInNewsOf(?User $user): bool
@@ -515,7 +525,6 @@ class Link
     public function toJson(User $context_user): array
     {
         $origin = null;
-        $source = null;
 
         if ($this->origin && auth\Access::can($context_user, 'viewOrigin', $this)) {
             $origin_formatter = new utils\OriginFormatter($context_user);
@@ -525,8 +534,6 @@ class Link
                 'label' => $origin_formatter->labelFromOrigin($this->origin),
                 'url' => $origin_formatter->urlFromOrigin($this->origin),
             ];
-
-            $source = $origin_formatter->sourceFromOrigin($this->origin);
         }
 
         return [
@@ -537,7 +544,7 @@ class Link
             'is_hidden' => $this->is_hidden,
             'reading_time' => $this->reading_time,
             'tags' => $this->tags,
-            'source' => $source, // @deprecated Can be removed in version 3.0.0.
+            'source' => $this->source_id,
             'origin' => $origin,
             'is_read' => $this->isReadBy($context_user),
             'is_read_later' => $this->isInBookmarksOf($context_user),

--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -298,7 +298,7 @@ trait Link
      *     properties.
      * @param array{
      *     'published_date'?: ?\DateTimeImmutable,
-     *     'origin'?: ?string,
+     *     'source'?: ?string,
      *     'hidden'?: bool,
      *     'offset'?: int,
      *     'limit'?: int|'ALL',
@@ -307,7 +307,7 @@ trait Link
      * Description of the options:
      *
      * - published_date (default to null), limits the selection to the given publication date
-     * - origin (default to null), limits the selection to the given origin
+     * - source (default to null), limits the selection to the given source
      * - hidden (default to true), indicates if hidden links must be included
      * - offset (default to 0), the offset for pagination
      * - limit (default to 'ALL') the limit for pagination
@@ -321,7 +321,7 @@ trait Link
     ): array {
         $default_options = [
             'published_date' => null,
-            'origin' => null,
+            'source' => null,
             'hidden' => true,
             'offset' => 0,
             'limit' => 'ALL',
@@ -356,11 +356,11 @@ trait Link
             $parameters[':published_date'] = $options['published_date']->format('Y-m-d');
         }
 
-        $origin = $options['origin'];
-        $origin_clause = '';
-        if ($origin) {
-            $origin_clause = 'AND origin = :origin';
-            $parameters[':origin'] = $origin;
+        $source = $options['source'];
+        $source_clause = '';
+        if ($source) {
+            $source_clause = 'AND source_id = :source';
+            $parameters[':source'] = $source;
         }
 
         $visibility_clause = '';
@@ -384,7 +384,7 @@ trait Link
             WHERE l.id = lc.link_id
             AND lc.collection_id = :collection_id
             {$date_clause}
-            {$origin_clause}
+            {$source_clause}
             {$visibility_clause}
 
             {$order_by_clause}

--- a/src/models/dao/links/NewsQueries.php
+++ b/src/models/dao/links/NewsQueries.php
@@ -33,7 +33,7 @@ trait NewsQueries
                 l.url_hash,
                 l.*,
                 lc.created_at AS published_at,
-                c.id AS initial_collection_id
+                c.id AS source_id
             FROM collections c, links_to_collections lc, followed_collections fc, links l
 
             WHERE fc.user_id = :user_id

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -181,13 +181,14 @@ CREATE TABLE links (
     search_index TSVECTOR GENERATED ALWAYS AS (to_tsvector('french', title || ' ' || url)) STORED,
     url_hash TEXT GENERATED ALWAYS AS (encode(digest(url, 'sha256'), 'hex')) STORED,
 
-    user_id TEXT REFERENCES users ON DELETE CASCADE ON UPDATE CASCADE
+    user_id TEXT REFERENCES users ON DELETE CASCADE ON UPDATE CASCADE,
+    source_id TEXT REFERENCES collections ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE INDEX idx_links_user_id_url_hash ON links USING btree(user_id, url_hash);
 CREATE INDEX idx_links_url_hash ON links USING hash(url_hash);
 CREATE INDEX idx_links_url ON links USING gin (url gin_trgm_ops);
-CREATE INDEX idx_links_origin ON links(origin) WHERE origin != '';
+CREATE INDEX idx_links_source_id ON links(source_id) WHERE source_id IS NOT NULL;
 CREATE INDEX idx_links_fetched_at ON links(fetched_at) WHERE fetched_at IS NULL;
 CREATE INDEX idx_links_fetched_retry_at ON links(fetched_retry_at) WHERE fetched_retry_at IS NOT NULL;
 CREATE INDEX idx_links_image_filename ON links(image_filename) WHERE image_filename IS NOT NULL;

--- a/src/utils/LinksTimeline/DateGroup.php
+++ b/src/utils/LinksTimeline/DateGroup.php
@@ -17,30 +17,27 @@ class DateGroup
     /** @var models\Link[] */
     public array $links = [];
 
-    /** @var array<string, OriginGroup> */
-    public array $origin_groups = [];
-
-    private utils\OriginFormatter $origin_formatter;
+    /** @var array<string, SourceGroup> */
+    public array $source_groups = [];
 
     public function __construct(\DateTimeImmutable $date)
     {
         $this->date = $date;
         $current_user = auth\CurrentUser::get();
-        $this->origin_formatter = new utils\OriginFormatter($current_user);
     }
 
     public function addLink(models\Link $link): void
     {
-        if ($link->origin) {
-            if (isset($this->origin_groups[$link->origin])) {
-                $origin_group = $this->origin_groups[$link->origin];
+        $source = $link->source();
+        if ($source) {
+            if (isset($this->source_groups[$source->id])) {
+                $source_group = $this->source_groups[$source->id];
             } else {
-                $label = $this->origin_formatter->labelFromOrigin($link->origin);
-                $origin_group = new OriginGroup($link->origin, $label);
-                $this->origin_groups[$link->origin] = $origin_group;
+                $source_group = new SourceGroup($source);
+                $this->source_groups[$source->id] = $source_group;
             }
 
-            $origin_group->links[] = $link;
+            $source_group->links[] = $link;
         } else {
             $this->links[] = $link;
         }
@@ -59,21 +56,23 @@ class DateGroup
     }
 
     /**
-     * Return the origin groups sorted by titles.
+     * Return the source groups sorted by titles.
      *
-     * @return OriginGroup[]
+     * @return SourceGroup[]
      */
-    public function originGroups(): array
+    public function sourceGroups(): array
     {
-        return utils\Sorter::localeSort($this->origin_groups, 'label');
+        return utils\Sorter::localeSort($this->source_groups, function (SourceGroup $sourceGroup): string {
+            return $sourceGroup->source->name();
+        });
     }
 
     public function count(): int
     {
         $count = count($this->links);
 
-        foreach ($this->origin_groups as $origin_group) {
-            $count += $origin_group->count();
+        foreach ($this->source_groups as $source_group) {
+            $count += $source_group->count();
         }
 
         return $count;

--- a/src/utils/LinksTimeline/SourceGroup.php
+++ b/src/utils/LinksTimeline/SourceGroup.php
@@ -8,11 +8,10 @@ use App\models;
  * @author  Marien Fressinaud <dev@marienfressinaud.fr>
  * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
  */
-class OriginGroup
+class SourceGroup
 {
     public function __construct(
-        public string $origin,
-        public string $label,
+        public models\Collection $source,
         /** @var models\Link[] */
         public array $links = [],
     ) {

--- a/src/views/news/index.html.twig
+++ b/src/views/news/index.html.twig
@@ -121,15 +121,15 @@
                                     </div>
                                 {% endif %}
 
-                                {% for origin_group in date_group.originGroups %}
-                                    <div class="origin-group flow flow--small">
-                                        <div class="origin-group__header cols cols--always cols--gap cols--center">
-                                            <h3 class="origin-group__title">
-                                                {{ origin_group.label }}
+                                {% for source_group in date_group.sourceGroups %}
+                                    <div class="source-group flow flow--small">
+                                        <div class="source-group__header cols cols--always cols--gap cols--center">
+                                            <h3 class="source-group__title">
+                                                {{ source_group.source.name() }}
                                             </h3>
 
                                             <span class="col--noshrink text--secondary">
-                                                {{ t('%s link', '%s links', origin_group.links | length, [origin_group.links | length]) }}
+                                                {{ t('%s link', '%s links', source_group.links | length, [source_group.links | length]) }}
                                             </span>
 
                                             <details
@@ -157,7 +157,7 @@
                                                         </button>
 
                                                         <input type="hidden" name="date" value="{{ date_group.date.format('Y-m-d') }}">
-                                                        <input type="hidden" name="origin" value="{{ origin_group.origin }}">
+                                                        <input type="hidden" name="source" value="{{ source_group.source.id }}">
                                                         <input type="hidden" name="csrf_token" value="{{ csrf_token('collections\\MarkCollectionAsRead') }}">
                                                     </form>
 
@@ -168,7 +168,7 @@
                                                         </button>
 
                                                         <input type="hidden" name="date" value="{{ date_group.date.format('Y-m-d') }}">
-                                                        <input type="hidden" name="origin" value="{{ origin_group.origin }}">
+                                                        <input type="hidden" name="source" value="{{ source_group.source.id }}">
                                                         <input type="hidden" name="csrf_token" value="{{ csrf_token('collections\\MarkCollectionAsReadLater') }}">
                                                     </form>
 
@@ -187,15 +187,15 @@
                                                         </button>
 
                                                         <input type="hidden" name="date" value="{{ date_group.date.format('Y-m-d') }}">
-                                                        <input type="hidden" name="origin" value="{{ origin_group.origin }}">
+                                                        <input type="hidden" name="source" value="{{ source_group.source.id }}">
                                                         <input type="hidden" name="csrf_token" value="{{ csrf_token('collections\\MarkCollectionAsNever') }}">
                                                     </form>
                                                 </nav>
                                             </details>
                                         </div>
 
-                                        <div class="origin-group__body grid">
-                                            {% for link in origin_group.links %}
+                                        <div class="source-group__body grid">
+                                            {% for link in source_group.links %}
                                                 {{ include('links/_link.html.twig', {
                                                     link: link,
                                                     from: url('news'),

--- a/tests/controllers/api/v1/journal/LaterTest.php
+++ b/tests/controllers/api/v1/journal/LaterTest.php
@@ -64,10 +64,9 @@ class LaterTest extends \PHPUnit\Framework\TestCase
         $user = $this->login();
         $news = $user->news();
         $collection = CollectionFactory::create();
-        $origin = \Minz\Url::absoluteFor('collection', ['id' => $collection->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin,
+            'source_id' => $collection->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
@@ -79,7 +78,7 @@ class LaterTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($link2->isInBookmarksOf($user));
 
         $response = $this->apiRun('POST', '/api/v1/journal/later', [
-            'origin' => $origin,
+            'source' => $collection->id,
         ]);
 
         $this->assertResponseCode($response, 200);

--- a/tests/controllers/api/v1/journal/LinksTest.php
+++ b/tests/controllers/api/v1/journal/LinksTest.php
@@ -64,10 +64,9 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $user = $this->login();
         $news = $user->news();
         $collection = CollectionFactory::create();
-        $origin = \Minz\Url::absoluteFor('collection', ['id' => $collection->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin,
+            'source_id' => $collection->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
@@ -79,7 +78,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($link2->isInNeverList($user));
 
         $response = $this->apiRun('DELETE', '/api/v1/journal/links', [
-            'origin' => $origin,
+            'source' => $collection->id,
         ]);
 
         $this->assertResponseCode($response, 200);

--- a/tests/controllers/api/v1/journal/ReadTest.php
+++ b/tests/controllers/api/v1/journal/ReadTest.php
@@ -64,10 +64,9 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         $user = $this->login();
         $news = $user->news();
         $collection = CollectionFactory::create();
-        $origin = \Minz\Url::absoluteFor('collection', ['id' => $collection->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin,
+            'source_id' => $collection->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
@@ -79,7 +78,7 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($link2->isReadBy($user));
 
         $response = $this->apiRun('POST', '/api/v1/journal/read', [
-            'origin' => $origin,
+            'source' => $collection->id,
         ]);
 
         $this->assertResponseCode($response, 200);

--- a/tests/controllers/collections/ReadTest.php
+++ b/tests/controllers/collections/ReadTest.php
@@ -135,22 +135,20 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         $news = $user->news();
         $collection1 = CollectionFactory::create();
         $collection2 = CollectionFactory::create();
-        $origin1 = \Minz\Url::absoluteFor('collection', ['id' => $collection1->id]);
-        $origin2 = \Minz\Url::absoluteFor('collection', ['id' => $collection2->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin1,
+            'source_id' => $collection1->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin2,
+            'source_id' => $collection2->id,
         ]);
         $link1->addCollection($news);
         $link2->addCollection($news);
 
         $response = $this->appRun('POST', "/collections/{$news->id}/read", [
             'csrf_token' => $this->csrfToken(forms\collections\MarkCollectionAsRead::class),
-            'origin' => $origin1,
+            'source' => $collection1->id,
         ]);
 
         $this->assertResponseCode($response, 302, '/');
@@ -332,22 +330,20 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         $news = $user->news();
         $collection1 = CollectionFactory::create();
         $collection2 = CollectionFactory::create();
-        $origin1 = \Minz\Url::absoluteFor('collection', ['id' => $collection1->id]);
-        $origin2 = \Minz\Url::absoluteFor('collection', ['id' => $collection2->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin1,
+            'source_id' => $collection1->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin2,
+            'source_id' => $collection2->id,
         ]);
         $link1->addCollection($news);
         $link2->addCollection($news);
 
         $response = $this->appRun('POST', "/collections/{$news->id}/read/later", [
             'csrf_token' => $this->csrfToken(forms\collections\MarkCollectionAsReadLater::class),
-            'origin' => $origin1,
+            'source' => $collection1->id,
         ]);
 
         $this->assertResponseCode($response, 302, '/');
@@ -523,22 +519,20 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         $news = $user->news();
         $collection1 = CollectionFactory::create();
         $collection2 = CollectionFactory::create();
-        $origin1 = \Minz\Url::absoluteFor('collection', ['id' => $collection1->id]);
-        $origin2 = \Minz\Url::absoluteFor('collection', ['id' => $collection2->id]);
         $link1 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin1,
+            'source_id' => $collection1->id,
         ]);
         $link2 = LinkFactory::create([
             'user_id' => $user->id,
-            'origin' => $origin2,
+            'source_id' => $collection2->id,
         ]);
         $link1->addCollection($news);
         $link2->addCollection($news);
 
         $response = $this->appRun('POST', "/collections/{$news->id}/read/never", [
             'csrf_token' => $this->csrfToken(forms\collections\MarkCollectionAsNever::class),
-            'origin' => $origin1,
+            'source' => $collection1->id,
         ]);
 
         $this->assertResponseCode($response, 302, '/');

--- a/tests/models/dao/links/NewsQueriesTest.php
+++ b/tests/models/dao/links/NewsQueriesTest.php
@@ -65,9 +65,9 @@ class NewsQueriesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(2, count($links));
         $this->assertSame($link2->id, $links[0]->id);
-        $this->assertSame($collection->id, $links[0]->initial_collection_id);
+        $this->assertSame($collection->id, $links[0]->source_id);
         $this->assertSame($link1->id, $links[1]->id);
-        $this->assertSame($collection->id, $links[1]->initial_collection_id);
+        $this->assertSame($collection->id, $links[1]->source_id);
     }
 
     public function testListFromFollowedCollectionsSelectsHiddenLinkIfCollectionIsShared(): void
@@ -105,7 +105,7 @@ class NewsQueriesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(1, count($links));
         $this->assertSame($link->id, $links[0]->id);
-        $this->assertSame($collection->id, $links[0]->initial_collection_id);
+        $this->assertSame($collection->id, $links[0]->source_id);
     }
 
     public function testListFromFollowedCollectionsSelectsFromPrivateCollectionIfShared(): void
@@ -143,7 +143,7 @@ class NewsQueriesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(1, count($links));
         $this->assertSame($link->id, $links[0]->id);
-        $this->assertSame($collection->id, $links[0]->initial_collection_id);
+        $this->assertSame($collection->id, $links[0]->source_id);
     }
 
     public function testListFromFollowedCollectionsRespectsFromFollowedIfOldLinksButWithTimeFilterAll(): void
@@ -184,7 +184,7 @@ class NewsQueriesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(1, count($links));
         $this->assertSame($link->id, $links[0]->id);
-        $this->assertSame($collection->id, $links[0]->initial_collection_id);
+        $this->assertSame($collection->id, $links[0]->source_id);
     }
 
     public function testListFromFollowedCollectionsDoesNotPickFromFollowedIfTooOld(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

This commit reverses part of the last changes, in particular 3a5adece and 685855bd. Origin is still available as the information is important, but source is used to group the links in the news, and to mark them (read/later/never).

This is because later features in Flus will need this information to stay consistent once set.

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Fill the news
2. Mark the links as read using the group actions
3. Check that it works

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
