### PR TITLE
fix: Fix look of collections if stored by someone else

### DIFF
--- a/src/controllers/links/Read.php
+++ b/src/controllers/links/Read.php
@@ -196,7 +196,7 @@ class Read extends BaseController
             return Response::found($from);
         }
 
-        models\LinkToCollection::markAsUnread($user, [$link->id]);
+        $user->unmarkAsRead($link);
 
         return Response::found($from);
     }

--- a/src/views/collections/_collections_by_others.html.twig
+++ b/src/views/collections/_collections_by_others.html.twig
@@ -1,4 +1,4 @@
-<ul class="list--collections-others list list--no-style">
+<ul class="list--collections-others list list--nostyle flow flow--smaller">
     {% for collection in collections %}
         {% set other_link = collection.linkNotOwnedByUrl(app.user.id, link.url_hash) %}
         {% set link_owner = other_link.owner %}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create two users
2. Create a collection with user A
3. Share the collection to user B
4. With user A, add a link in the shared collection
5. With user B, go to the collection and show the collections of the link
6. Verify the collection appears at the top, without the bullet point

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
