### PR TITLE
fix: Remove underline for links origins

### DIFF
--- a/src/assets/stylesheets/components/links.css
+++ b/src/assets/stylesheets/components/links.css
@@ -147,6 +147,7 @@
 
 .link__origin a {
     color: currentcolor;
+    text-decoration: none;
 }
 
 .link__notepad {


### PR DESCRIPTION
## Related issue(s)

I know it's bad for accessibility, but I find that it really clutters up the interface and makes it harder to read.
    
The origin anchor is still in bold to make it more visible and encourage people to click on it. Not perfect though.

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Fill the news
2. check the "via …" origins are not underlined

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
