### PR TITLE
fix: Fix duration calculation in Json+LD

### DIFF
--- a/lib/SpiderBits/src/JsonLd.php
+++ b/lib/SpiderBits/src/JsonLd.php
@@ -51,6 +51,18 @@ class JsonLd
             }
         }
 
+        foreach ($node as $child_node) {
+            if (!is_array($child_node)) {
+                continue;
+            }
+
+            $duration = $this->durationFromNode($child_node);
+
+            if ($duration) {
+                return $duration;
+            }
+        }
+
         return '';
     }
 

--- a/tests/lib/SpiderBits/JsonLdTest.php
+++ b/tests/lib/SpiderBits/JsonLdTest.php
@@ -58,4 +58,22 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame('PT2520', $duration);
     }
+
+    public function testDurationInRootArray(): void
+    {
+        $json_ld_array = [
+            [
+                '@context' => 'http://schema.org',
+                '@type' => 'VideoObject',
+                'name' => 'My video',
+                'url' => 'https://videos.example.com/my-video',
+                'duration' => 'PT2520',
+            ]
+        ];
+        $json_ld = new JsonLd($json_ld_array);
+
+        $duration = $json_ld->duration();
+
+        $this->assertSame('PT2520', $duration);
+    }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Add a link to an Apple podcast
2. Verify the estimated duration is correct

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
