### PR TITLE
chore: Fix setup of Altcha

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "repository": "github:flusio/Flus",
   "type": "module",
   "scripts": {
-    "watch": "esbuild --bundle --loader:.woff=file --loader:.woff2=file --loader:.svg=file --sourcemap --outdir=public/dev_assets --watch=forever src/assets/*/application.*",
-    "build": "esbuild --bundle --loader:.woff=file --loader:.woff2=file --loader:.svg=file --sourcemap --outdir=public/assets --minify src/assets/*/application.*",
+    "watch": "esbuild --bundle --loader:.woff=file --loader:.woff2=file --loader:.svg=file --sourcemap --outdir=public/dev_assets --watch=forever src/assets/*/application.* src/assets/javascripts/altcha.js",
+    "build": "esbuild --bundle --loader:.woff=file --loader:.woff2=file --loader:.svg=file --sourcemap --outdir=public/assets --minify src/assets/*/application.* src/assets/javascripts/altcha.js",
     "lint-js": "eslint -c .eslint.config.js src/assets/javascripts/",
     "lint-js-fix": "eslint -c .eslint.config.js --fix src/assets/javascripts/",
     "lint-css": "stylelint src/assets/stylesheets/**/*.css",

--- a/src/assets/javascripts/altcha.js
+++ b/src/assets/javascripts/altcha.js
@@ -1,0 +1,2 @@
+import 'altcha';
+import 'altcha/i18n/fr-fr';

--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -1,9 +1,6 @@
 import * as Turbo from '@hotwired/turbo';
 import { Application } from '@hotwired/stimulus';
 
-import 'altcha';
-import 'altcha/i18n/fr-fr';
-
 import AutosubmitController from './controllers/autosubmit_controller.js';
 import AutosaveController from './controllers/autosave_controller.js';
 import BackButtonController from './controllers/back_button_controller.js';

--- a/src/views/registrations/new.html.twig
+++ b/src/views/registrations/new.html.twig
@@ -14,6 +14,7 @@
 {% block head_additional_tags %}
     {# Require a full reload of the page if Altcha is enabled as CSP headers are set. #}
     {% if form.mustCheckAltcha() %}
+        <script src="{{ url_asset('javascripts/altcha.js') }}" data-turbo-track="reload" defer></script>
         <meta name="turbo-visit-control" content="reload">
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Related issue(s)

This avoids to include the code of Altcha in application.js while:

1. Altcha may be not enabled
2. Altcha is only used on the registration page

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Enable Altcha in the .env file
1. Go on the registration page
2. Verify that the Altcha widget appears
3. Verify that a dedicated altcha.js script is loaded

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
