### PR TITLE
fix: Fix grouping links by dates and forgetting URL status on link deletion

### DIFF
--- a/src/controllers/Links.php
+++ b/src/controllers/Links.php
@@ -331,6 +331,7 @@ class Links extends BaseController
             return Response::found($from);
         }
 
+        $user->unmark($link);
         $link->remove();
 
         return Response::found($from);

--- a/src/models/UrlStatus.php
+++ b/src/models/UrlStatus.php
@@ -171,7 +171,7 @@ class UrlStatus
     }
 
     /**
-     * Mark the links as dismissed and remove them from the journal of the user.
+     * Mark the links as dismissed for the user.
      *
      * @param Link|Link[] $links
      */
@@ -206,6 +206,41 @@ class UrlStatus
             VALUES {$values_placeholder}
             ON CONFLICT (user_id, url_hash) DO UPDATE SET
                 dismissed_at = excluded.dismissed_at
+        SQL;
+
+        $database = Database::get();
+        $statement = $database->prepare($sql);
+        $statement->execute($values);
+    }
+
+    /**
+     * Unmark the links for the user (aka remove the corresponding URL statuses).
+     *
+     * @param Link|Link[] $links
+     */
+    public static function unmark(User $user, Link|array $links): void
+    {
+        if ($links instanceof Link) {
+            $links = [$links];
+        }
+
+        if (!$links) {
+            return;
+        }
+
+        $values_as_question_marks = [];
+        $values = [$user->id];
+
+        foreach ($links as $link) {
+            $values_as_question_marks[] = '?';
+            $values[] = $link->url_hash;
+        }
+        $values_placeholder = implode(", ", $values_as_question_marks);
+
+        $sql = <<<SQL
+            DELETE FROM url_statuses
+            WHERE user_id = ?
+            AND url_hash IN ({$values_placeholder})
         SQL;
 
         $database = Database::get();

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -731,6 +731,20 @@ class User
     }
 
     /**
+     * Unmark the links for the user (aka remove the corresponding URL statuses).
+     *
+     * @param Link|Link[] $links
+     */
+    public function unmark(Link|array $links): void
+    {
+        if ($links instanceof Link) {
+            $links = [$links];
+        }
+
+        UrlStatus::unmark($this, $links);
+    }
+
+    /**
      * Set the user password.
      */
     public function setPassword(string $password): void

--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -353,8 +353,13 @@ trait Link
 
         $date_clause = '';
         if ($options['published_date'] !== null) {
-            $date_clause = "AND date_trunc('day', lc.created_at) = :published_date";
-            $parameters[':published_date'] = $options['published_date']->format('Y-m-d');
+            $date_clause = "AND lc.created_at >= :published_start AND lc.created_at <= :published_end";
+
+            $start = $options['published_date']->modify('00:00:00');
+            $end = $start->modify('23:59:59');
+
+            $parameters[':published_start'] = $start->format(Database\Column::DATETIME_FORMAT);
+            $parameters[':published_end'] = $end->format(Database\Column::DATETIME_FORMAT);
         }
 
         $source = $options['source'];

--- a/src/utils/LinksTimeline.php
+++ b/src/utils/LinksTimeline.php
@@ -25,11 +25,20 @@ class LinksTimeline
                 continue;
             }
 
-            $date_key = $link->published_at->format('Y-m-d');
+            // The key is formatted using translateDate (using IntlDateFormatter
+            // internally) because the output can differ from the format method
+            // of DateTimeInterface. This happens because of the timezone. For
+            // instance, a "2026-06-24 22:30:00" DateTime in UTC+2 would be
+            // formatted "2026-06-24" with DateTime::format, and "2026-06-25"
+            // with TwigExtension::translateDate. As we display the dates in
+            // the interface using the latter, the key MUST be coherent.
+            $date_key = \Minz\Template\TwigExtension::translateDate($link->published_at, 'Y-MM-dd');
+
             if (isset($this->dates_groups[$date_key])) {
                 $date_group = $this->dates_groups[$date_key];
             } else {
-                $date_group = new LinksTimeline\DateGroup($link->published_at);
+                $date = new \DateTimeImmutable($date_key);
+                $date_group = new LinksTimeline\DateGroup($date);
                 $this->dates_groups[$date_key] = $date_group;
             }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,9 @@ date_default_timezone_set('UTC');
 
 \Minz\Engine::startSession();
 
+// Make sure to set the locale.
+\App\utils\Locale::setCurrentLocale('en_GB');
+
 \Minz\Database::reset();
 $schema = @file_get_contents(\App\Configuration::$schema_path);
 

--- a/tests/controllers/LinksTest.php
+++ b/tests/controllers/LinksTest.php
@@ -956,6 +956,9 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $link = LinkFactory::create([
             'user_id' => $user->id,
         ]);
+        $user->markAsRead($link);
+
+        $this->assertTrue($user->hasRead($link));
 
         $response = $this->appRun('POST', "/links/{$link->id}/delete", [
             'csrf_token' => $this->csrfToken(forms\links\DeleteLink::class),
@@ -963,6 +966,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
 
         $this->assertResponseCode($response, 302, '/');
         $this->assertFalse(models\Link::exists($link->id));
+        $this->assertFalse($user->hasRead($link));
     }
 
     public function testDeleteRedirectsIfNotConnected(): void

--- a/tests/utils/LinksTimelineTest.php
+++ b/tests/utils/LinksTimelineTest.php
@@ -15,7 +15,7 @@ class LinksTimelineTest extends \PHPUnit\Framework\TestCase
         $link2 = LinkFactory::create();
         $link2->published_at = new \DateTimeImmutable('2024-03-22 12:00');
         $link3 = LinkFactory::create();
-        $link3->published_at = new \DateTimeImmutable('2024-03-20 12:00');
+        $link3->published_at = new \DateTimeImmutable('2024-03-21 00:00+0200');
         $links = [$link1, $link2, $link3];
 
         $timeline = new LinksTimeline($links);
@@ -25,11 +25,11 @@ class LinksTimelineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(2, count($dates_groups));
         $group1 = $dates_groups['2024-03-20'];
         $group2 = $dates_groups['2024-03-22'];
-        $this->assertEquals($link1->published_at, $group1->date);
+        $this->assertEquals($link1->published_at->modify('00:00:00'), $group1->date);
         $this->assertSame(2, count($group1->links));
         $this->assertSame($link1->id, $group1->links[0]->id);
         $this->assertSame($link3->id, $group1->links[1]->id);
-        $this->assertEquals($link2->published_at, $group2->date);
+        $this->assertEquals($link2->published_at->modify('00:00:00'), $group2->date);
         $this->assertSame(1, count($group2->links));
         $this->assertSame($link2->id, $group2->links[0]->id);
     }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Make sure to have a link being saved as '2026-06-24 23:30:00+00' **in the database** in a feed that you follow while your timezone is set to something like Europe/Paris
2. Refresh the news
3. Make sure the link is displayed as being published the day after, 25th June 2026 at 01:30
4. Verify that it is present in the correct date group and that you can mark it as read from the date actions
5. Delete the link
6. Verify there is not any more a corresponding UrlStatus in the database 

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
