### PR TITLE
feat(alpha): Add a command to migrate groups to streams

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -302,6 +302,7 @@ class Router
         $router->addRoute('CLI', '/migrations/create', 'Migrations#create');
         $router->addRoute('CLI', '/migrations/reset', 'Migrations#reset');
         $router->addRoute('CLI', '/migrations/setup-url-statuses', 'Migrations#setupUrlStatuses');
+        $router->addRoute('CLI', '/migrations/setup-streams', 'Migrations#setupStreams');
 
         $router->addRoute('CLI', '/media/clean', 'Media#clean');
 

--- a/src/cli/Help.php
+++ b/src/cli/Help.php
@@ -64,6 +64,8 @@ class Help
         $usage .= "  migrations               List the migrations\n";
         $usage .= "  migrations setup         Initialize or migrate the application\n";
         $usage .= "      [--seed=BOOL]        Whether you want to seed the application or not (default: false)\n";
+        $usage .= "  migrations setup-streams Setup streams from existing groups of followed collections\n";
+        $usage .= "      --user=ID            ID of the user to migrate\n";
         $usage .= "  migrations setup-url-statuses Apply url_statuses database migration (TO APPLY BEFORE 3.0)\n";
         $usage .= "      [--batch-size=INT]   Size of batches (default to 1000)\n";
         $usage .= "      [--dry-run=BOOL]     Don’t apply the migration but get data volume (default: false)\n";

--- a/src/cli/Migrations.php
+++ b/src/cli/Migrations.php
@@ -2,6 +2,7 @@
 
 namespace App\cli;
 
+use App\models;
 use Minz\Request;
 use Minz\Response;
 
@@ -192,5 +193,79 @@ class Migrations extends \Minz\Migration\Controller
         }
 
         yield Response::text(200, "Finished: {$total} statuses migrated.");
+    }
+
+    /**
+     * Apply migration to setup Streams from existing groups of followed collections.
+     *
+     * The command can be executed several times: streams are matched to groups
+     * by their name, and existing sources are not duplicated.
+     *
+     * @request_param string user
+     *     The id of the user for whom to migrate the groups.
+     *
+     * @response 400
+     *     If the user doesn't exist.
+     * @response 200
+     *     On success.
+     */
+    public function setupStreams(Request $request): Response
+    {
+        $user_id = $request->parameters->getString('user', '');
+        $user = models\User::find($user_id);
+
+        if (!$user) {
+            return Response::text(400, 'User does not exist.');
+        }
+
+        $followed_collections = models\FollowedCollection::listBy([
+            'user_id' => $user->id,
+        ]);
+
+        $groups_by_ids = [];
+        $collections_by_group_ids = [];
+
+        foreach ($followed_collections as $followed_collection) {
+            if (!$followed_collection->group_id) {
+                continue;
+            }
+
+            if (isset($groups_by_ids[$followed_collection->group_id])) {
+                $group = $groups_by_ids[$followed_collection->group_id];
+            } else {
+                $group = models\Group::require($followed_collection->group_id);
+                $groups_by_ids[$group->id] = $group;
+            }
+
+            $collection = models\Collection::require($followed_collection->collection_id);
+
+            if (!isset($collections_by_group_ids[$group->id])) {
+                $collections_by_group_ids[$group->id] = [];
+            }
+
+            $collections_by_group_ids[$group->id][] = $collection;
+        }
+
+        foreach ($groups_by_ids as $group) {
+            $stream = models\Stream::findBy([
+                'user_id' => $user->id,
+                'name' => $group->name,
+            ]);
+
+            if (!$stream) {
+                $stream = $user->initStream();
+                $stream->name = $group->name;
+                $stream->save();
+            }
+
+            foreach ($collections_by_group_ids[$group->id] as $collection) {
+                $stream->addSource($collection);
+            }
+        }
+
+        return Response::text(
+            200,
+            "Followed collections groups migrated to streams successfully for user {$user->email}.",
+        );
     }
 }

--- a/tests/cli/MigrationsTest.php
+++ b/tests/cli/MigrationsTest.php
@@ -3,6 +3,9 @@
 namespace App\cli;
 
 use App\models;
+use tests\factories\CollectionFactory;
+use tests\factories\FollowedCollectionFactory;
+use tests\factories\GroupFactory;
 use tests\factories\LinkFactory;
 use tests\factories\LinkToCollectionFactory;
 use tests\factories\UserFactory;
@@ -267,5 +270,93 @@ class MigrationsTest extends \PHPUnit\Framework\TestCase
             $link_dismissed_at->getTimestamp(),
             $status_link->dismissed_at?->getTimestamp()
         );
+    }
+
+    public function testSetupStreams(): void
+    {
+        self::recreateDatabase();
+
+        $user = UserFactory::create();
+        $group = GroupFactory::create([
+            'user_id' => $user->id,
+            'name' => 'My group',
+        ]);
+        $collection_1 = CollectionFactory::create();
+        $collection_2 = CollectionFactory::create();
+        $collection_3 = CollectionFactory::create();
+        FollowedCollectionFactory::create([
+            'user_id' => $user->id,
+            'collection_id' => $collection_1->id,
+            'group_id' => $group->id,
+        ]);
+        FollowedCollectionFactory::create([
+            'user_id' => $user->id,
+            'collection_id' => $collection_2->id,
+            'group_id' => $group->id,
+        ]);
+        FollowedCollectionFactory::create([
+            'user_id' => $user->id,
+            'collection_id' => $collection_3->id,
+            'group_id' => null,
+        ]);
+
+        $response = $this->appRun('CLI', '/migrations/setup-streams', [
+            'user' => $user->id,
+        ]);
+
+        $this->assertResponseCode($response, 200);
+        $streams = models\Stream::listBy(['user_id' => $user->id]);
+        $this->assertSame(1, count($streams));
+        $stream = $streams[0];
+        $this->assertSame('My group', $stream->name);
+        $sources_ids = array_column($stream->sources(), 'id');
+        sort($sources_ids);
+        $expected_sources_ids = [$collection_1->id, $collection_2->id];
+        sort($expected_sources_ids);
+        $this->assertSame($expected_sources_ids, $sources_ids);
+    }
+
+    public function testSetupStreamsCanBeExecutedTwice(): void
+    {
+        self::recreateDatabase();
+
+        $user = UserFactory::create();
+        $group = GroupFactory::create([
+            'user_id' => $user->id,
+            'name' => 'My group',
+        ]);
+        $collection = CollectionFactory::create();
+        FollowedCollectionFactory::create([
+            'user_id' => $user->id,
+            'collection_id' => $collection->id,
+            'group_id' => $group->id,
+        ]);
+
+        $response = $this->appRun('CLI', '/migrations/setup-streams', [
+            'user' => $user->id,
+        ]);
+        $this->assertResponseCode($response, 200);
+
+        $response = $this->appRun('CLI', '/migrations/setup-streams', [
+            'user' => $user->id,
+        ]);
+
+        $this->assertResponseCode($response, 200);
+        $streams = models\Stream::listBy(['user_id' => $user->id]);
+        $this->assertSame(1, count($streams));
+        $stream = $streams[0];
+        $this->assertSame([$collection->id], array_column($stream->sources(), 'id'));
+    }
+
+    public function testSetupStreamsFailsIfUserDoesNotExist(): void
+    {
+        self::recreateDatabase();
+
+        $response = $this->appRun('CLI', '/migrations/setup-streams', [
+            'user' => 'not-an-id',
+        ]);
+
+        $this->assertResponseCode($response, 400);
+        $this->assertResponseEquals($response, 'User does not exist.');
     }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Follow feeds/collections
2. Put them into groups
3. Execute the command
4. Verify that streams are named after the groups
5. Execute the command a second time and verify that streams are not duplicated

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
