### PR TITLE
fix: Fix the Altcha CSP headers

### DIFF
--- a/src/controllers/Registrations.php
+++ b/src/controllers/Registrations.php
@@ -116,14 +116,19 @@ class Registrations extends BaseController
         return $response;
     }
 
+    /**
+     * Set the CSP headers required by the Altcha widget.
+     *
+     * Altcha runs its proof of work in workers created from blobs.
+     *
+     * The <style> element that Altcha injects doesn't need a dedicated
+     * directive: it is allowed by the style-src set in the Application, which
+     * permits 'unsafe-inline'.
+     */
     public function setAltchaCSPHeaders(Response $response): void
     {
         if (\App\Configuration::$application['registration_captcha']) {
             $response->setContentSecurityPolicy('worker-src', "'self' blob:");
-            $response->setContentSecurityPolicy(
-                'style-src-elem',
-                "'self' 'sha256-egofkfASsSTkzuyfBiXWBobV9ZDK4UIMKiNlvLr9nNE=' 'unsafe-hashes'"
-            );
         }
     }
 }

--- a/tests/controllers/RegistrationsTest.php
+++ b/tests/controllers/RegistrationsTest.php
@@ -34,6 +34,34 @@ class RegistrationsTest extends \PHPUnit\Framework\TestCase
         $this->assertResponseCode($response, 302, '/');
     }
 
+    public function testNewSetsTheAltchaCSPHeadersIfCaptchaIsEnabled(): void
+    {
+        \App\Configuration::$application['registration_captcha'] = true;
+
+        $response = $this->appRun('GET', '/registration');
+
+        \App\Configuration::$application['registration_captcha'] = false;
+        $this->assertResponseCode($response, 200);
+        $this->assertResponseHeaders($response, [
+            'Content-Security-Policy' => [
+                'default-src' => "'self'",
+                'worker-src' => "'self' blob:",
+                'style-src' => "'self' 'unsafe-inline'",
+            ],
+        ]);
+    }
+
+    public function testNewDoesNotSetTheAltchaCSPHeadersIfCaptchaIsDisabled(): void
+    {
+        $response = $this->appRun('GET', '/registration');
+
+        $this->assertResponseCode($response, 200);
+        $this->assertInstanceOf(\Minz\Response::class, $response);
+        $csp = $response->headers(true)['Content-Security-Policy'];
+        $this->assertIsArray($csp);
+        $this->assertArrayNotHasKey('worker-src', $csp);
+    }
+
     public function testNewRedirectsToLoginIfRegistrationsAreClosed(): void
     {
         \App\Configuration::$application['registrations_opened'] = false;
@@ -452,5 +480,29 @@ class RegistrationsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, models\User::count());
         $this->assertResponseCode($response, 400);
         $this->assertResponseContains($response, 'You must accept the terms of service');
+    }
+
+    public function testCreateFailsAndSetsTheAltchaCSPHeadersIfCaptchaIsEnabled(): void
+    {
+        \App\Configuration::$application['registration_captcha'] = true;
+
+        $response = $this->appRun('POST', '/registration', [
+            'csrf_token' => $this->csrfToken(forms\Registration::class),
+            'username' => $this->fake('name'),
+            'email' => $this->fake('email'),
+            'password' => $this->fake('password'),
+        ]);
+
+        \App\Configuration::$application['registration_captcha'] = false;
+        $this->assertSame(0, models\User::count());
+        $this->assertResponseCode($response, 400);
+        $this->assertResponseContains($response, 'The captcha has not been completed');
+        $this->assertResponseHeaders($response, [
+            'Content-Security-Policy' => [
+                'default-src' => "'self'",
+                'worker-src' => "'self' blob:",
+                'style-src' => "'self' 'unsafe-inline'",
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Enable Altcha
2. Go to the registration page
3. Verify that the Altcha widget is not broken

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
