### PR TITLE
fix: Fix repairing links in read and read later lists

### DIFF
--- a/src/controllers/links/Repairing.php
+++ b/src/controllers/links/Repairing.php
@@ -95,14 +95,20 @@ class Repairing extends BaseController
         }
 
         if ($link->url !== $form->url) {
-            // Mark the old link as dismissed to avoid the link reappearing in
-            // the news.
             $old_link = models\Link::copy($link, $user->id);
             $old_link->save();
+
+            $link->url = $form->url;
+            $link->save();
+
+            // Transfer the URL status so the link stays in the "read" and "to
+            // read later" lists after its URL changed.
+            $user->transferUrlStatus($old_link, $link);
+
+            // Mark the old link as dismissed to avoid the link reappearing in
+            // the news.
             $user->markAsDismissed($old_link);
         }
-
-        $link->url = $form->url;
 
         $link_fetcher_service = new services\LinkFetcher([
             'http_timeout' => 10,

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -771,6 +771,33 @@ class User
     }
 
     /**
+     * Transfer the URL status from a Link to another one.
+     *
+     * The status of the old Link URL is deleted and its states are copied to
+     * the status of the new Link URL. The existing states of the new URL are
+     * preserved.
+     */
+    public function transferUrlStatus(Link $old_link, Link $new_link): void
+    {
+        $old_url_status = UrlStatus::findOrBuild($this, $old_link->url);
+
+        if (!$old_url_status->isPersisted()) {
+            return;
+        }
+
+        $new_url_status = UrlStatus::findOrBuild($this, $new_link->url);
+        $new_url_status->created_at ??= $old_url_status->created_at;
+        $new_url_status->read_at ??= $old_url_status->read_at;
+        $new_url_status->read_later_at ??= $old_url_status->read_later_at;
+        $new_url_status->dismissed_at ??= $old_url_status->dismissed_at;
+        $new_url_status->save();
+
+        $old_url_status->remove();
+
+        $this->unmemoizeUrlStatusesOfLinks([$old_link, $new_link]);
+    }
+
+    /**
      * Get the UrlStatus corresponding to this user and link.
      *
      * A UrlStatus is always returned. In case it is unknown to the user, a

--- a/tests/controllers/links/RepairingTest.php
+++ b/tests/controllers/links/RepairingTest.php
@@ -211,6 +211,92 @@ class RepairingTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($user->hasDismissed($link));
     }
 
+    public function testCreateTransfersTheReadLaterStatusToTheNewUrl(): void
+    {
+        $user = $this->login();
+        /** @var string */
+        $old_url = $this->fakeUnique('url');
+        $new_url = 'https://flus.fr/carnet/index.html';
+        $link = LinkFactory::create([
+            'user_id' => $user->id,
+            'url' => $old_url,
+        ]);
+        $user->markAsReadLater($link);
+        $this->mockHttpWithFixture($new_url, 'responses/flus.fr_carnet_index.html');
+
+        $response = $this->appRun('POST', "/links/{$link->id}/repair", [
+            'url' => $new_url,
+            'force_sync' => false,
+            'csrf_token' => $this->csrfToken(forms\links\RepairLink::class),
+        ]);
+
+        $this->assertResponseCode($response, 302, "/links/{$link->id}/repair");
+        $read_later_source = $user->readLaterSource();
+        $read_later_links = $read_later_source->links();
+        $this->assertSame(1, count($read_later_links));
+        $this->assertSame($link->id, $read_later_links[0]->id);
+        $this->assertSame($new_url, $read_later_links[0]->url);
+        $this->assertFalse($user->hasReadLater($link));
+    }
+
+    public function testCreateTransfersTheReadStatusToTheNewUrl(): void
+    {
+        $user = $this->login();
+        /** @var string */
+        $old_url = $this->fakeUnique('url');
+        $new_url = 'https://flus.fr/carnet/index.html';
+        $link = LinkFactory::create([
+            'user_id' => $user->id,
+            'url' => $old_url,
+        ]);
+        $user->markAsRead($link);
+        $this->mockHttpWithFixture($new_url, 'responses/flus.fr_carnet_index.html');
+
+        $response = $this->appRun('POST', "/links/{$link->id}/repair", [
+            'url' => $new_url,
+            'force_sync' => false,
+            'csrf_token' => $this->csrfToken(forms\links\RepairLink::class),
+        ]);
+
+        $this->assertResponseCode($response, 302, "/links/{$link->id}/repair");
+        $read_source = $user->readSource();
+        $read_links = $read_source->links();
+        $this->assertSame(1, count($read_links));
+        $this->assertSame($link->id, $read_links[0]->id);
+        $this->assertSame($new_url, $read_links[0]->url);
+        $this->assertFalse($user->hasRead($link));
+    }
+
+    public function testCreateKeepsTheExistingStatusOfTheNewUrl(): void
+    {
+        $user = $this->login();
+        /** @var string */
+        $old_url = $this->fakeUnique('url');
+        $new_url = 'https://flus.fr/carnet/index.html';
+        $link = LinkFactory::create([
+            'user_id' => $user->id,
+            'url' => $old_url,
+        ]);
+        $other_link = LinkFactory::create([
+            'user_id' => $user->id,
+            'url' => $new_url,
+        ]);
+        $user->markAsReadLater($link);
+        $user->markAsRead($other_link);
+        $this->mockHttpWithFixture($new_url, 'responses/flus.fr_carnet_index.html');
+
+        $response = $this->appRun('POST', "/links/{$link->id}/repair", [
+            'url' => $new_url,
+            'force_sync' => false,
+            'csrf_token' => $this->csrfToken(forms\links\RepairLink::class),
+        ]);
+
+        $this->assertResponseCode($response, 302, "/links/{$link->id}/repair");
+        $link = $link->reload();
+        $this->assertTrue($user->hasRead($link));
+        $this->assertTrue($user->hasReadLater($link));
+    }
+
     public function testCreateDoesNotDismissTheUrlIfUnchanged(): void
     {
         $user = $this->login();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Mark a link to read later
2. Repair the link by changing its url
3. Verify that the new URL is present in the read later links (and not the old one)

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
