### PR TITLE
fix: Fix rendering the modal after applying a stream filter

### DIFF
--- a/src/assets/javascripts/controllers/modal_controller.js
+++ b/src/assets/javascripts/controllers/modal_controller.js
@@ -29,14 +29,6 @@ export default class extends Controller {
         this.element.addEventListener('keydown', this.trapEscape.bind(this));
         this.element.addEventListener('keydown', this.trapFocus.bind(this));
 
-        // set focus elements when the modal is loaded
-        document.documentElement.addEventListener('turbo:frame-render', (event) => {
-            if (event.target === this.contentTarget) {
-                this.setFocus();
-                this.boxTarget.scrollIntoView(true);
-            }
-        });
-
         if (this.autoloadValue) {
             const openModalEvent = new CustomEvent('open-modal', {
                 detail: {
@@ -46,6 +38,12 @@ export default class extends Controller {
             });
             this.element.dispatchEvent(openModalEvent);
         }
+    }
+
+    // Set the focus elements when the modal content is loaded.
+    focusContent () {
+        this.setFocus();
+        this.boxTarget.scrollIntoView(true);
     }
 
     setFocus () {

--- a/src/assets/javascripts/controllers/modal_controller.js
+++ b/src/assets/javascripts/controllers/modal_controller.js
@@ -23,11 +23,6 @@ export default class extends Controller {
     }
 
     connect () {
-        // Set the id of the content turbo-frame. It must not be set directly
-        // in the HTML, or Turbo will try to load its content when a form in
-        // the modal redirects to a new page (instead of showing the full HTML).
-        this.contentTarget.setAttribute('id', 'modal-content');
-
         this.element.addEventListener('open-modal', this.open.bind(this));
 
         // handle modal shortcuts
@@ -107,7 +102,12 @@ export default class extends Controller {
         layout.setAttribute('aria-hidden', true);
         document.body.classList.add('modal-opened');
 
-        // load the modal content via turbo-frame
+        // Load the modal content via turbo-frame. The id of the frame is set
+        // here and not in the HTML, or Turbo would try to load its content
+        // when a form in the modal redirects to a new page (instead of
+        // showing the full HTML). It's not set in connect() either, as a
+        // morphing refresh would remove it (the server never renders it).
+        this.contentTarget.setAttribute('id', 'modal-content');
         this.contentTarget.setAttribute('src', event.detail.href);
 
         // remember the current element to give it the focus back on close
@@ -134,7 +134,8 @@ export default class extends Controller {
         // unload the turbo-frame with a timeout to wait for the modal close
         // animation
         setTimeout(() => {
-            this.contentTarget.setAttribute('src', '');
+            this.contentTarget.removeAttribute('src');
+            this.contentTarget.removeAttribute('id');
             this.contentTarget.innerHTML = '<div class="spinner"></div>';
         }, 300);
 

--- a/src/views/layouts/_modal_dialog.html.twig
+++ b/src/views/layouts/_modal_dialog.html.twig
@@ -27,7 +27,10 @@
         </header>
 
         <div data-modal-target="body" class="modal__body">
-            <turbo-frame data-modal-target="content">
+            <turbo-frame
+                data-modal-target="content"
+                data-action="turbo:frame-render->modal#focusContent"
+            >
                 <div class="flow text--center">
                     <p class="text--bold">
                         {{ t('Loading…') }}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Navigate to a stream
2. Apply a filter
3. Try to open a modal (e.g. "new stream")
4. Verify that the modal is correctly loaded

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
