### PR TITLE
fix: Handle invalid query when searching in links

### DIFF
--- a/src/controllers/Links.php
+++ b/src/controllers/Links.php
@@ -42,22 +42,25 @@ class Links extends BaseController
         $pagination_page = $request->parameters->getInteger('page', 1);
 
         if ($query) {
-            $search_query = search_engine\Query::fromString($query);
-
-            $number_links = search_engine\LinksSearcher::countLinks($user, $search_query);
-
             $number_per_page = 30;
 
-            $pagination = new utils\Pagination($number_links, $number_per_page, $pagination_page);
+            $search_query = search_engine\Query::fromStringOrNull($query);
 
-            $links = search_engine\LinksSearcher::getLinks(
-                $user,
-                $search_query,
-                pagination: [
-                    'offset' => $pagination->currentOffset(),
-                    'limit' => $pagination->numberPerPage(),
-                ]
-            );
+            if ($search_query) {
+                $number_links = search_engine\LinksSearcher::countLinks($user, $search_query);
+                $pagination = new utils\Pagination($number_links, $number_per_page, $pagination_page);
+                $links = search_engine\LinksSearcher::getLinks(
+                    $user,
+                    $search_query,
+                    pagination: [
+                        'offset' => $pagination->currentOffset(),
+                        'limit' => $pagination->numberPerPage(),
+                    ]
+                );
+            } else {
+                $pagination = new utils\Pagination(0, $number_per_page, $pagination_page);
+                $links = [];
+            }
 
             models\links\Preloader::for($links)
                 ->originsFor($user)

--- a/tests/controllers/LinksTest.php
+++ b/tests/controllers/LinksTest.php
@@ -82,6 +82,24 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->assertResponseNotContains($response, $title_2);
     }
 
+    public function testIndexRendersNoResultWhenQueryIsMalformed(): void
+    {
+        $user = $this->login();
+        /** @var string */
+        $title = $this->fakeUnique('words', 3, true);
+        LinkFactory::create([
+            'title' => $title,
+        ]);
+
+        $response = $this->appRun('GET', '/links', [
+            'q' => '""',
+        ]);
+
+        $this->assertResponseCode($response, 200);
+        $this->assertResponseTemplateName($response, 'links/search.html.twig');
+        $this->assertResponseNotContains($response, $title);
+    }
+
     public function testIndexRendersCollectionsSharedWithWriteAccess(): void
     {
         $user = $this->login();


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Search for `#` in the link search bar
2. Verify that it doesn't fail and show an empty list of links

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
