### PR TITLE
fix(stream): Don't suggest the "all" filter for news

### DIFF
--- a/src/models/Collection.php
+++ b/src/models/Collection.php
@@ -638,6 +638,9 @@ class Collection
      *
      * Above a few links a day, no filter can keep the news readable: the
      * collection is better followed in a stream, so "none" is suggested.
+     *
+     * "all" is never suggested as it would be too easy to get overwhelmed
+     * by the news.
      */
     public function suggestedTimeFilter(): string
     {
@@ -651,12 +654,7 @@ class Collection
             return 'strict';
         }
 
-        if ($this->publication_frequency_per_year >= 52) {
-            // At least one link per week.
-            return 'normal';
-        }
-
-        return 'all';
+        return 'normal';
     }
 
     /**
@@ -674,7 +672,6 @@ class Collection
         }
 
         $groups = [
-            'all' => 'quiet',
             'normal' => 'weekly',
             'strict' => 'daily',
             'none' => 'prolific',

--- a/tests/models/CollectionTest.php
+++ b/tests/models/CollectionTest.php
@@ -102,10 +102,11 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             // At least one link per week, but less than one per day.
             [364, 'normal'],
             [52, 'normal'],
-            // Less than one link per week.
-            [51, 'all'],
-            [1, 'all'],
-            [0, 'all'],
+            // Less than one link per week ("all" could theoretically be
+            // suggested, but it would flood the news too easily then).
+            [51, 'normal'],
+            [1, 'normal'],
+            [0, 'normal'],
         ];
     }
 
@@ -128,8 +129,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [0, 'inactive'],
-            [1, 'quiet'],
-            [51, 'quiet'],
+            [1, 'weekly'],
+            [51, 'weekly'],
             [52, 'weekly'],
             [364, 'weekly'],
             [365, 'daily'],


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open the list of sources
2. Make sure that the "all" time filter is not recommended for any source

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
