### PR TITLE
fix: Display number of notes in all lists with preloading

### DIFF
--- a/src/controllers/Bookmarks.php
+++ b/src/controllers/Bookmarks.php
@@ -111,7 +111,8 @@ class Bookmarks extends BaseController
         models\links\Preloader::for($links)
             ->originsFor($user)
             ->urlStatusesFor($user)
-            ->numberCollectionsFor($user);
+            ->numberCollectionsFor($user)
+            ->numberNotes();
 
         return Response::ok('bookmarks/index.html.twig', [
             'read_later_source' => $read_later_source,

--- a/src/controllers/Collections.php
+++ b/src/controllers/Collections.php
@@ -136,7 +136,7 @@ class Collections extends BaseController
         $topics = utils\Sorter::localeSort($topics, 'label');
 
         $links = $collection->links(
-            ['published_at', 'number_notes'],
+            ['published_at'],
             [
                 'hidden' => $can_update || $access_is_shared,
                 'offset' => $pagination->currentOffset(),
@@ -147,7 +147,8 @@ class Collections extends BaseController
         models\links\Preloader::for($links)
             ->originsFor($user)
             ->urlStatusesFor($user)
-            ->numberCollectionsFor($user);
+            ->numberCollectionsFor($user)
+            ->numberNotes();
 
         return Response::ok('collections/show.html.twig', [
             'collection' => $collection,

--- a/src/controllers/Links.php
+++ b/src/controllers/Links.php
@@ -65,7 +65,8 @@ class Links extends BaseController
             models\links\Preloader::for($links)
                 ->originsFor($user)
                 ->urlStatusesFor($user)
-                ->numberCollectionsFor($user);
+                ->numberCollectionsFor($user)
+                ->numberNotes();
 
             return Response::ok('links/search.html.twig', [
                 'links' => $links,

--- a/src/controllers/News.php
+++ b/src/controllers/News.php
@@ -31,7 +31,7 @@ class News extends BaseController
         $user = auth\CurrentUser::require();
 
         $news = $user->news();
-        $links = $news->links(['published_at', 'number_notes']);
+        $links = $news->links(['published_at']);
 
         models\links\Preloader::for($links)
             ->sources()

--- a/src/controllers/Read.php
+++ b/src/controllers/Read.php
@@ -42,7 +42,8 @@ class Read extends BaseController
         models\links\Preloader::for($links)
             ->originsFor($user)
             ->urlStatusesFor($user)
-            ->numberCollectionsFor($user);
+            ->numberCollectionsFor($user)
+            ->numberNotes();
 
         return Response::ok('read/index.html.twig', [
             'read_source' => $read_source,

--- a/src/controllers/api/v1/Journal.php
+++ b/src/controllers/api/v1/Journal.php
@@ -24,12 +24,13 @@ class Journal extends BaseController
         $user = auth\CurrentUser::require();
 
         $news = $user->news();
-        $links = $news->links(['published_at', 'number_notes']);
+        $links = $news->links(['published_at']);
 
         models\links\Preloader::for($links)
             ->collections()
             ->originsFor($user)
-            ->urlStatusesFor($user);
+            ->urlStatusesFor($user)
+            ->numberNotes();
 
         return Response::json(200, array_map(function (models\Link $link) use ($user): array {
             return $link->toJson(context_user: $user);

--- a/src/controllers/api/v1/Links.php
+++ b/src/controllers/api/v1/Links.php
@@ -81,7 +81,7 @@ class Links extends BaseController
         $pagination = new utils\Pagination($number_links, $pagination_per_page, $pagination_page);
 
         $links = $collection->links(
-            ['published_at', 'number_notes'],
+            ['published_at'],
             [
                 'hidden' => $can_view_hidden_links,
                 'offset' => $pagination->currentOffset(),
@@ -92,7 +92,8 @@ class Links extends BaseController
         models\links\Preloader::for($links)
             ->collections()
             ->originsFor($user)
-            ->urlStatusesFor($user);
+            ->urlStatusesFor($user)
+            ->numberNotes();
 
         return Response::json(200, array_map(function (models\Link $link) use ($user): array {
             return $link->toJson(context_user: $user);
@@ -110,6 +111,12 @@ class Links extends BaseController
         $pagination = new utils\Pagination($number_links, $pagination_per_page, $pagination_page);
 
         $links = $source->links($pagination);
+
+        models\links\Preloader::for($links)
+            ->collections()
+            ->originsFor($user)
+            ->urlStatusesFor($user)
+            ->numberNotes();
 
         return Response::json(200, array_map(function (models\Link $link) use ($user): array {
             return $link->toJson(context_user: $user);

--- a/src/controllers/profiles/Links.php
+++ b/src/controllers/profiles/Links.php
@@ -43,7 +43,7 @@ class Links extends BaseController
         $pagination_page = $request->parameters->getInteger('page', 1);
         $pagination = new utils\Pagination($number_links, 30, $pagination_page);
 
-        $links = $user->links(['published_at', 'number_notes'], [
+        $links = $user->links(['published_at'], [
             'unshared' => false,
             'tag' => $tag,
             'offset' => $pagination->currentOffset(),
@@ -52,7 +52,8 @@ class Links extends BaseController
 
         models\links\Preloader::for($links)
             ->urlStatusesFor($current_user)
-            ->numberCollectionsFor($current_user);
+            ->numberCollectionsFor($current_user)
+            ->numberNotes();
 
         return Response::ok('profiles/links/index.html.twig', [
             'user' => $user,

--- a/src/forms/Search.php
+++ b/src/forms/Search.php
@@ -43,10 +43,10 @@ class Search extends BaseForm
         return $this->memoize('existing_link', function (): ?models\Link {
             $user = $this->optionAs('user', models\User::class);
 
-            return models\Link::findComputedBy([
+            return models\Link::findBy([
                 'user_id' => $user->id,
                 'url_hash' => utils\Belt::hashUrl($this->url),
-            ], ['number_notes']);
+            ]);
         });
     }
 

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -125,59 +125,6 @@ class Link
     }
 
     /**
-     * Return a link with its computed properties.
-     *
-     * @param DatabaseCriteria $criteria
-     *     The conditions the link must match.
-     * @param string[] $selected_computed_props
-     *     The list of computed properties to return. It is mandatory to
-     *     select specific properties to avoid computing dispensable
-     *     properties.
-     */
-    public static function findComputedBy(array $criteria, array $selected_computed_props): ?self
-    {
-        // Note that publication date is usually computed by considering the
-        // date of association with a collection. Without collection, we
-        // consider its date of insertion in the database.
-        $published_at_clause = '';
-        if (in_array('published_at', $selected_computed_props)) {
-            $published_at_clause = ', l.created_at AS published_at';
-        }
-
-        $number_notes_clause = '';
-        if (in_array('number_notes', $selected_computed_props)) {
-            $number_notes_clause = <<<'SQL'
-                , (
-                    SELECT COUNT(*) FROM notes m
-                    WHERE m.link_id = l.id
-                ) AS number_notes
-            SQL;
-        }
-
-        list($where_statement, $parameters) = Database\Helper::buildWhere($criteria);
-
-        $sql = <<<SQL
-            SELECT
-                l.*
-                {$published_at_clause}
-                {$number_notes_clause}
-            FROM links l
-            WHERE {$where_statement}
-        SQL;
-
-        $database = Database::get();
-        $statement = $database->prepare($sql);
-        $statement->execute($parameters);
-
-        $result = $statement->fetch();
-        if (is_array($result)) {
-            return self::fromDatabaseRow($result);
-        } else {
-            return null;
-        }
-    }
-
-    /**
      * Set the origin of the link.
      *
      * It is useful to keep the old source_type and source_resource_id columns

--- a/src/models/Note.php
+++ b/src/models/Note.php
@@ -124,6 +124,48 @@ class Note
     }
 
     /**
+     * Return the numbers of notes attached to the given links, indexed by the
+     * ids of these links.
+     *
+     * The links without any note are absent from the returned array.
+     *
+     * @param Link[] $links
+     *
+     * @return array<string, int>
+     */
+    public static function countByLinks(array $links): array
+    {
+        if (!$links) {
+            return [];
+        }
+
+        $link_ids = array_column($links, 'id');
+        $ids_as_question_marks = array_fill(0, count($link_ids), '?');
+        $ids_as_question_marks = implode(', ', $ids_as_question_marks);
+
+        $sql = <<<SQL
+            SELECT link_id, COUNT(*) AS count
+            FROM notes
+
+            WHERE link_id IN ({$ids_as_question_marks})
+
+            GROUP BY link_id
+        SQL;
+
+        $database = Database::get();
+        $statement = $database->prepare($sql);
+        $statement->execute($link_ids);
+
+        $counts = [];
+
+        foreach ($statement->fetchAll() as $row) {
+            $counts[$row['link_id']] = intval($row['count']);
+        }
+
+        return $counts;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toJson(): array

--- a/src/models/links/Annotable.php
+++ b/src/models/links/Annotable.php
@@ -3,7 +3,6 @@
 namespace App\models\links;
 
 use App\models\Note;
-use Minz\Database;
 
 /**
  * Add the notes that a user can attach to a link.
@@ -15,9 +14,6 @@ use Minz\Database;
  */
 trait Annotable
 {
-    #[Database\Column(computed: true)]
-    public ?int $number_notes = null;
-
     /**
      * Return the notes attached to the current link
      *
@@ -81,17 +77,26 @@ trait Annotable
         $this->refreshTags();
     }
 
+    /**
+     * Return the number of notes attached to the current link
+     */
     public function numberNotes(): int
     {
-        if ($this->number_notes !== null) {
-            return $this->number_notes;
-        }
-
-        return $this->memoize('count_notes', function (): int {
+        return $this->memoize('number_notes', function (): int {
             return Note::countBy([
                 'link_id' => $this->id,
             ]);
         });
+    }
+
+    /**
+     * Set the number of notes without querying the database.
+     *
+     * @see Preloader
+     */
+    public function preloadNumberNotes(int $number): void
+    {
+        $this->memoizeValue('number_notes', $number);
     }
 
     /**
@@ -102,8 +107,7 @@ trait Annotable
      */
     private function unmemoizeNotes(): void
     {
-        $this->number_notes = null;
         $this->unmemoize('notes');
-        $this->unmemoize('count_notes');
+        $this->unmemoize('number_notes');
     }
 }

--- a/src/models/links/InCollections.php
+++ b/src/models/links/InCollections.php
@@ -266,16 +266,6 @@ trait InCollections
             $order_by_clause = 'ORDER BY lc.created_at DESC, l.id';
         }
 
-        $number_notes_clause = '';
-        if (in_array('number_notes', $selected_computed_props)) {
-            $number_notes_clause = <<<'SQL'
-                , (
-                    SELECT COUNT(*) FROM notes m
-                    WHERE m.link_id = l.id
-                ) AS number_notes
-            SQL;
-        }
-
         $date_clause = '';
         if ($options['published_date'] !== null) {
             $date_clause = "AND lc.created_at >= :published_start AND lc.created_at <= :published_end";
@@ -309,7 +299,6 @@ trait InCollections
             SELECT
                 l.*
                 {$published_at_clause}
-                {$number_notes_clause}
             FROM links l, links_to_collections lc
 
             WHERE l.id = lc.link_id

--- a/src/models/links/OwnedByUser.php
+++ b/src/models/links/OwnedByUser.php
@@ -159,16 +159,6 @@ trait OwnedByUser
             $order_by_clause = 'ORDER BY published_at DESC, l.id';
         }
 
-        $number_notes_clause = '';
-        if (in_array('number_notes', $selected_computed_props)) {
-            $number_notes_clause = <<<'SQL'
-                , (
-                    SELECT COUNT(*) FROM notes m
-                    WHERE m.link_id = l.id
-                ) AS number_notes
-            SQL;
-        }
-
         $visibility_clause = '';
         $join_clause = '';
         $group_by_clause = '';
@@ -206,7 +196,6 @@ trait OwnedByUser
             SELECT
                 l.*
                 {$published_at_clause}
-                {$number_notes_clause}
             FROM links l
 
             {$join_clause}

--- a/src/models/links/Preloader.php
+++ b/src/models/links/Preloader.php
@@ -4,6 +4,7 @@ namespace App\models\links;
 
 use App\models\Collection;
 use App\models\Link;
+use App\models\Note;
 use App\models\UrlStatus;
 use App\models\User;
 use App\utils\OriginFormatter;
@@ -71,6 +72,20 @@ class Preloader
 
         foreach ($this->links as $link) {
             $link->preloadCollections($collections_by_link_ids[$link->id] ?? []);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Preload the number of notes attached to the links.
+     */
+    public function numberNotes(): self
+    {
+        $numbers_by_link_ids = Note::countByLinks($this->links);
+
+        foreach ($this->links as $link) {
+            $link->preloadNumberNotes($numbers_by_link_ids[$link->id] ?? 0);
         }
 
         return $this;

--- a/src/search_engine/LinksSearcher.php
+++ b/src/search_engine/LinksSearcher.php
@@ -48,11 +48,7 @@ class LinksSearcher
         $sql = <<<SQL
             SELECT
                 l.*,
-                l.created_at AS published_at,
-                (
-                    SELECT COUNT(*) FROM notes n
-                    WHERE n.link_id = l.id
-                ) AS number_notes
+                l.created_at AS published_at
             FROM links l
 
             WHERE l.user_id = :user_id

--- a/src/views/links/_link.html.twig
+++ b/src/views/links/_link.html.twig
@@ -189,8 +189,8 @@
                     <span class="col--extend">
                         <a class="link__notepad" href="{{ url('link', { id: link.id }) }}">
                             {{ icon('notepad') }}
-                            {% if link.number_notes > 0 %}
-                                {{ t('Notepad (%s)', [link.number_notes | format_number]) }}
+                            {% if link.numberNotes > 0 %}
+                                {{ t('Notepad (%s)', [link.numberNotes | format_number]) }}
                             {% else %}
                                 {{ t('Notepad') }}
                             {% endif %}

--- a/tests/models/links/OwnedByUserTest.php
+++ b/tests/models/links/OwnedByUserTest.php
@@ -99,21 +99,6 @@ class OwnedByUserTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($published_at, $links[0]->published_at);
     }
 
-    public function testListComputedByUserCanReturnNumberNotes(): void
-    {
-        $user = UserFactory::create();
-        $link = LinkFactory::create([
-            'user_id' => $user->id,
-        ]);
-        NoteFactory::create([
-            'link_id' => $link->id,
-        ]);
-
-        $links = models\Link::listComputedByUser($user, ['number_notes']);
-
-        $this->assertSame(1, $links[0]->number_notes);
-    }
-
     public function testListComputedByUserCanListSharedOnly(): void
     {
         $user = UserFactory::create();

--- a/tests/models/links/PreloaderTest.php
+++ b/tests/models/links/PreloaderTest.php
@@ -242,6 +242,26 @@ class PreloaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, $link->numberCollectionsForUser($user));
     }
 
+    public function testNumberNotesPreloadsTheNumbersOfNotes(): void
+    {
+        $user = UserFactory::create();
+        $link_with_two_notes = LinkFactory::create(['user_id' => $user->id]);
+        $link_with_one_note = LinkFactory::create(['user_id' => $user->id]);
+        $link_without_note = LinkFactory::create(['user_id' => $user->id]);
+        $link_with_two_notes->addNote(new models\Note($user, 'First note'));
+        $link_with_two_notes->addNote(new models\Note($user, 'Second note'));
+        $link_with_one_note->addNote(new models\Note($user, 'A note'));
+
+        $links = [$link_with_two_notes, $link_with_one_note, $link_without_note];
+        Preloader::for($links)->numberNotes();
+
+        models\Note::deleteBy(['user_id' => $user->id]);
+
+        $this->assertSame(2, $link_with_two_notes->numberNotes());
+        $this->assertSame(1, $link_with_one_note->numberNotes());
+        $this->assertSame(0, $link_without_note->numberNotes());
+    }
+
     public function testPreloadingAcceptsAnEmptyListOfLinks(): void
     {
         $user = UserFactory::create();
@@ -250,7 +270,8 @@ class PreloaderTest extends \PHPUnit\Framework\TestCase
             ->sources()
             ->collections()
             ->urlStatusesFor($user)
-            ->numberCollectionsFor($user);
+            ->numberCollectionsFor($user)
+            ->numberNotes();
 
         $this->assertInstanceOf(Preloader::class, $preloader);
     }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Mark a link as read / read later
2. Add notes to it
3. Verify that the number of notes is displayed in the "read later" and "read" lists

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
