### PR TITLE
fix: Don't delete users if subscription is ongoing

### DIFF
--- a/src/jobs/scheduled/Cleaner.php
+++ b/src/jobs/scheduled/Cleaner.php
@@ -45,6 +45,7 @@ class Cleaner extends \Minz\Job
         models\User::deleteInactiveAndNotified(
             inactive_since: \Minz\Time::ago(12, 'months'),
             notified_since: \Minz\Time::ago(1, 'month'),
+            except_subscribed: \App\Configuration::areSubscriptionsEnabled(),
         );
         models\Collection::deleteUnfollowedFeedsOlderThan(\Minz\Time::ago(7, 'days'));
         models\Link::deleteDetachedOlderThan(\Minz\Time::ago(7, 'days'));

--- a/src/jobs/scheduled/InactivityNotifier.php
+++ b/src/jobs/scheduled/InactivityNotifier.php
@@ -35,7 +35,10 @@ class InactivityNotifier extends \Minz\Job
     public function perform(): void
     {
         $inactive_since = \Minz\Time::ago(11, 'months');
-        $inactive_users = models\User::listInactiveAndNotNotified($inactive_since);
+        $inactive_users = models\User::listInactiveAndNotNotified(
+            $inactive_since,
+            except_subscribed: \App\Configuration::areSubscriptionsEnabled(),
+        );
 
         $mailer = new mailers\Users();
 

--- a/src/mailers/Users.php
+++ b/src/mailers/Users.php
@@ -120,6 +120,11 @@ class Users extends Mailer
             return null;
         }
 
+        if (\App\Configuration::areSubscriptionsEnabled() && !$user->isSubscriptionOverdue()) {
+            \Minz\Log::warning("Can’t send inactivity email to user {$user_id} (subscription is active)");
+            return null;
+        }
+
         utils\Locale::setCurrentLocale($user->locale);
 
         $email = new Mailer\Email();

--- a/src/models/dao/User.php
+++ b/src/models/dao/User.php
@@ -139,10 +139,14 @@ trait User
 
     /**
      * Delete the inactive users that have been notified about it.
+     *
+     * If $except_subscribed is true, the users with an active subscription are
+     * not deleted.
      */
     public static function deleteInactiveAndNotified(
         \DateTimeImmutable $inactive_since,
-        \DateTimeImmutable $notified_since
+        \DateTimeImmutable $notified_since,
+        bool $except_subscribed = false,
     ): bool {
         $sql = <<<SQL
             DELETE FROM users
@@ -150,12 +154,20 @@ trait User
             AND deletion_notified_at <= :notified_since
         SQL;
 
-        $database = Database::get();
-        $statement = $database->prepare($sql);
-        return $statement->execute([
+        $parameters = [
             ':inactive_since' => $inactive_since->format(Database\Column::DATETIME_FORMAT),
             ':notified_since' => $notified_since->format(Database\Column::DATETIME_FORMAT),
-        ]);
+        ];
+
+        if ($except_subscribed) {
+            [$overdue_clause, $overdue_parameters] = self::sqlOverdueSubscription();
+            $sql .= $overdue_clause;
+            $parameters += $overdue_parameters;
+        }
+
+        $database = Database::get();
+        $statement = $database->prepare($sql);
+        return $statement->execute($parameters);
     }
 
     /**
@@ -184,22 +196,54 @@ trait User
     /**
      * Return the users that haven't be active since the given date.
      *
+     * If $except_subscribed is true, the users with an active subscription are
+     * not returned.
+     *
      * @return self[]
      */
-    public static function listInactiveAndNotNotified(\DateTimeImmutable $inactive_since): array
-    {
+    public static function listInactiveAndNotNotified(
+        \DateTimeImmutable $inactive_since,
+        bool $except_subscribed = false,
+    ): array {
         $sql = <<<'SQL'
             SELECT * FROM users
             WHERE last_activity_at <= :inactive_since
             AND deletion_notified_at IS NULL
         SQL;
 
+        $parameters = [
+            ':inactive_since' => $inactive_since->format(Database\Column::DATETIME_FORMAT),
+        ];
+
+        if ($except_subscribed) {
+            [$overdue_clause, $overdue_parameters] = self::sqlOverdueSubscription();
+            $sql .= $overdue_clause;
+            $parameters += $overdue_parameters;
+        }
+
         $database = Database::get();
         $statement = $database->prepare($sql);
-        $statement->execute([
-            ':inactive_since' => $inactive_since->format(Database\Column::DATETIME_FORMAT),
-        ]);
+        $statement->execute($parameters);
 
         return self::fromDatabaseRows($statement->fetchAll());
+    }
+
+    /**
+     * Return a SQL clause (and its parameters) matching the users whose
+     * subscription is overdue (i.e. neither active nor exempted).
+     *
+     * @return array{string, array<string, string>}
+     */
+    private static function sqlOverdueSubscription(): array
+    {
+        $sql = ' AND subscription_expired_at <= :now AND subscription_expired_at > :exempted_date';
+
+        $exempted_date = new \DateTimeImmutable('@0');
+        $parameters = [
+            ':now' => \Minz\Time::now()->format(Database\Column::DATETIME_FORMAT),
+            ':exempted_date' => $exempted_date->format(Database\Column::DATETIME_FORMAT),
+        ];
+
+        return [$sql, $parameters];
     }
 }

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -253,6 +253,12 @@ class Subscriptions
 
             $user = $account_ids_to_users[$account_id];
             if ($user->subscription_expired_at != $expired_at) {
+                // The user may have been warned about the deletion of their
+                // account, but they renewed their subscription: make sure to
+                // forget the notification so they will be warned again if their
+                // subscription expires while still inactive.
+                $user->deletion_notified_at = null;
+
                 $user->subscription_expired_at = $expired_at;
                 $user->save();
             }

--- a/tests/jobs/scheduled/CleanerTest.php
+++ b/tests/jobs/scheduled/CleanerTest.php
@@ -19,6 +19,12 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
     use \tests\FakerHelper;
     use \tests\HttpHelper;
 
+    #[\PHPUnit\Framework\Attributes\After]
+    public function resetSubscriptionConfiguration(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = false;
+    }
+
     public function testQueue(): void
     {
         $cleaner_job = new Cleaner();
@@ -206,6 +212,66 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
         $cleaner_job->perform();
 
         $this->assertFalse(models\User::exists($user->id));
+    }
+
+    public function testPerformDeletesInactiveAndNotifiedUsersWithOverdueSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $cleaner_job = new Cleaner();
+        $inactivity_months = 12;
+        $notified_months = 1;
+        $subscription_expired_at = \Minz\Time::ago(1, 'month');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => \Minz\Time::ago($notified_months, 'months'),
+            'validated_at' => \Minz\Time::now(),
+            'subscription_expired_at' => $subscription_expired_at,
+        ]);
+
+        $cleaner_job->perform();
+
+        $this->assertFalse(models\User::exists($user->id));
+    }
+
+    public function testPerformKeepsInactiveAndNotifiedUsersWithActiveSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $cleaner_job = new Cleaner();
+        $inactivity_months = 12;
+        $notified_months = 1;
+        $subscription_expired_at = \Minz\Time::fromNow(1, 'month');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => \Minz\Time::ago($notified_months, 'months'),
+            'validated_at' => \Minz\Time::now(),
+            'subscription_expired_at' => $subscription_expired_at,
+        ]);
+
+        $cleaner_job->perform();
+
+        $this->assertTrue(models\User::exists($user->id));
+    }
+
+    public function testPerformKeepsInactiveAndNotifiedUsersWithExemptedSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $cleaner_job = new Cleaner();
+        $inactivity_months = 12;
+        $notified_months = 1;
+        $subscription_expired_at = new \DateTimeImmutable('1970-01-01');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => \Minz\Time::ago($notified_months, 'months'),
+            'validated_at' => \Minz\Time::now(),
+            'subscription_expired_at' => $subscription_expired_at,
+        ]);
+
+        $cleaner_job->perform();
+
+        $this->assertTrue(models\User::exists($user->id));
     }
 
     public function testPerformKeepsInactiveButNotNotifiedUsers(): void

--- a/tests/jobs/scheduled/InactivityNotifierTest.php
+++ b/tests/jobs/scheduled/InactivityNotifierTest.php
@@ -19,6 +19,12 @@ class InactivityNotifierTest extends \PHPUnit\Framework\TestCase
         \Minz\Engine::init($router);
     }
 
+    #[\PHPUnit\Framework\Attributes\After]
+    public function resetSubscriptionConfiguration(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = false;
+    }
+
     public function testQueue(): void
     {
         $job = new InactivityNotifier();
@@ -129,6 +135,76 @@ class InactivityNotifierTest extends \PHPUnit\Framework\TestCase
             'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
             'deletion_notified_at' => $notified_at,
             'validated_at' => $validated_at,
+        ]);
+
+        $job->perform();
+
+        $user = $user->reload();
+        $this->assertNull($user->deletion_notified_at);
+        $this->assertEmailsCount(0);
+    }
+
+    public function testPerformNotifiesUsersWithOverdueSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $now = \Minz\Time::now();
+        $job = new InactivityNotifier();
+        $inactivity_months = 11;
+        $notified_at = null;
+        $validated_at = \Minz\Time::ago(1, 'year');
+        $subscription_expired_at = \Minz\Time::ago(1, 'month');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => $notified_at,
+            'validated_at' => $validated_at,
+            'subscription_expired_at' => $subscription_expired_at,
+        ]);
+
+        $job->perform();
+
+        $user = $user->reload();
+        $this->assertSame($now->getTimestamp(), $user->deletion_notified_at?->getTimestamp());
+        $this->assertEmailsCount(1);
+    }
+
+    public function testPerformIgnoresUsersWithActiveSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $job = new InactivityNotifier();
+        $inactivity_months = 11;
+        $notified_at = null;
+        $validated_at = \Minz\Time::ago(1, 'year');
+        $subscription_expired_at = \Minz\Time::fromNow(1, 'month');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => $notified_at,
+            'validated_at' => $validated_at,
+            'subscription_expired_at' => $subscription_expired_at,
+        ]);
+
+        $job->perform();
+
+        $user = $user->reload();
+        $this->assertNull($user->deletion_notified_at);
+        $this->assertEmailsCount(0);
+    }
+
+    public function testPerformIgnoresUsersWithExemptedSubscription(): void
+    {
+        \App\Configuration::$application['subscriptions_enabled'] = true;
+        $this->freeze();
+        $job = new InactivityNotifier();
+        $inactivity_months = 11;
+        $notified_at = null;
+        $validated_at = \Minz\Time::ago(1, 'year');
+        $subscription_expired_at = new \DateTimeImmutable('1970-01-01');
+        $user = UserFactory::create([
+            'last_activity_at' => \Minz\Time::ago($inactivity_months, 'months'),
+            'deletion_notified_at' => $notified_at,
+            'validated_at' => $validated_at,
+            'subscription_expired_at' => $subscription_expired_at,
         ]);
 
         $job->perform();

--- a/tests/jobs/scheduled/SubscriptionsSyncTest.php
+++ b/tests/jobs/scheduled/SubscriptionsSyncTest.php
@@ -7,6 +7,7 @@ use tests\factories\UserFactory;
 class SubscriptionsSyncTest extends \PHPUnit\Framework\TestCase
 {
     use \Minz\Tests\InitializerHelper;
+    use \Minz\Tests\TimeHelper;
     use \tests\FakerHelper;
     use \tests\HttpHelper;
 
@@ -78,6 +79,74 @@ class SubscriptionsSyncTest extends \PHPUnit\Framework\TestCase
 
         $user = $user->reload();
         $this->assertEquals($new_expired_at, $user->subscription_expired_at);
+    }
+
+    public function testSyncResetsDeletionNotifiedAtIfSubscriptionIsRenewed(): void
+    {
+        /** @var \DateTimeImmutable */
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+        $subscriptions_host = \App\Configuration::$application['subscriptions_host'];
+        $subscriptions_sync_job = new SubscriptionsSync();
+        /** @var string */
+        $account_id = $this->fake('uuid');
+        $old_expired_at = \Minz\Time::ago(1, 'month');
+        $new_expired_at = \Minz\Time::fromNow(1, 'year');
+        $subscription_api_url = "{$subscriptions_host}/api/accounts/sync";
+        $this->mockHttpWithResponse($subscription_api_url, <<<TEXT
+            HTTP/2 200
+            Content-type: application/json
+
+            {
+                "{$account_id}": "{$new_expired_at->format(\Minz\Database\Column::DATETIME_FORMAT)}"
+            }
+            TEXT
+        );
+        $user = UserFactory::create([
+            'subscription_account_id' => $account_id,
+            'subscription_expired_at' => $old_expired_at,
+            'deletion_notified_at' => \Minz\Time::ago(1, 'week'),
+        ]);
+
+        $subscriptions_sync_job->perform();
+
+        $user = $user->reload();
+        $this->assertEquals($new_expired_at, $user->subscription_expired_at);
+        $this->assertNull($user->deletion_notified_at);
+    }
+
+    public function testSyncKeepsDeletionNotifiedAtIfSubscriptionIsNotRenewed(): void
+    {
+        /** @var \DateTimeImmutable */
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+        $subscriptions_host = \App\Configuration::$application['subscriptions_host'];
+        $subscriptions_sync_job = new SubscriptionsSync();
+        /** @var string */
+        $account_id = $this->fake('uuid');
+        $expired_at = \Minz\Time::ago(1, 'month');
+        $deletion_notified_at = \Minz\Time::ago(1, 'week');
+        $subscription_api_url = "{$subscriptions_host}/api/accounts/sync";
+        $this->mockHttpWithResponse($subscription_api_url, <<<TEXT
+            HTTP/2 200
+            Content-type: application/json
+
+            {
+                "{$account_id}": "{$expired_at->format(\Minz\Database\Column::DATETIME_FORMAT)}"
+            }
+            TEXT
+        );
+        $user = UserFactory::create([
+            'subscription_account_id' => $account_id,
+            'subscription_expired_at' => $expired_at,
+            'deletion_notified_at' => $deletion_notified_at,
+        ]);
+
+        $subscriptions_sync_job->perform();
+
+        $user = $user->reload();
+        $this->assertEquals($expired_at, $user->subscription_expired_at);
+        $this->assertEquals($deletion_notified_at, $user->deletion_notified_at);
     }
 
     public function testSyncGetsAccountIdIfMissing(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Setup an inactive user with a valid subscription
2. Run the InactivityNotifier job
3. Verify the mail is not sent
4. Set `$deletion_notified_at` to 1 month ago and run the Cleaner job
5. Verify that the user is not deleted

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
