### PR TITLE
fix: Fix the outline visibility in the popups

### DIFF
--- a/src/assets/stylesheets/layouts/popup.css
+++ b/src/assets/stylesheets/layouts/popup.css
@@ -1,7 +1,11 @@
 .popup__items {
+    position: relative;
+
     overflow-y: auto;
 
     max-height: min(60vh, 25rem);
+    margin: calc(-1 * var(--space-small)) calc(-1 * var(--space-smaller));
+    padding: var(--space-small) var(--space-smaller);
 }
 
 @media (max-width: 799px) {


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open a popup
2. Select the first element of the popup
3. Verify that the outline is not cropped by the container, nor hovered by the "before" arrow element

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works in both light and dark modes
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] The API provides the corresponding endpoints / data
- [x] Tests are up to date
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
